### PR TITLE
Fix: use AniDB Anime/Episode instead of Shoko Series/Episode objects

### DIFF
--- a/LuaRenamer/LuaContext.cs
+++ b/LuaRenamer/LuaContext.cs
@@ -186,7 +186,7 @@ end
         var anidb = AniDbFileToDict();
         var mediainfo = MediaInfoToDict();
         var importfolders = _renamer.AvailableFolders.Select(ImportFolderToDict).ToList();
-        var file = FileToDict(anidb, mediainfo, importfolders);
+        var file = FileToDict(anidb, mediainfo);
         var episodes = EpisodesToDict();
         var groups = GroupsToDict(animeCache);
 
@@ -235,8 +235,8 @@ end
         {
             var groupdict = new Dictionary<string, object?>();
             groupdict.Add(LuaEnv.group.name, g.PreferredTitle);
-            groupdict.Add(LuaEnv.group.mainanime, AnimeToDict(g.MainSeries, animeCache));
-            groupdict.Add(LuaEnv.group.animes, g.Series.Select(a => AnimeToDict(a, animeCache)).ToList());
+            groupdict.Add(LuaEnv.group.mainanime, AnimeToDict(g.MainSeries.AnidbAnime, animeCache));
+            groupdict.Add(LuaEnv.group.animes, g.AllSeries.Select(a => AnimeToDict(a.AnidbAnime, animeCache)).ToList());
             return groupdict;
         }).ToList();
         return groups;
@@ -346,8 +346,7 @@ end
     }
 
     [SuppressMessage("ReSharper", "UseObjectOrCollectionInitializer")]
-    private Dictionary<string, object?> FileToDict(Dictionary<string, object?>? anidb, Dictionary<string, object?>? mediainfo,
-        List<Dictionary<string, object>> importfolders)
+    private Dictionary<string, object?> FileToDict(Dictionary<string, object?>? anidb, Dictionary<string, object?>? mediainfo)
     {
         var file = new Dictionary<string, object?>();
         file.Add(LuaEnv.file.name, Path.GetFileNameWithoutExtension(_renamer.FileInfo.FileName));

--- a/LuaRenamer/LuaRenamer.cs
+++ b/LuaRenamer/LuaRenamer.cs
@@ -24,8 +24,8 @@ public class LuaRenamer : IRenamer
     public IVideo VideoInfo { get; private set; } = null!;
     public IRenameScript Script { get; private set; } = null!;
     public IList<IShokoGroup> GroupInfo { get; private set; } = null!;
-    public IList<IShokoEpisode> EpisodeInfo { get; private set; } = null!;
-    public IList<IShokoSeries> AnimeInfo { get; private set; } = null!;
+    public IList<IEpisode> EpisodeInfo { get; private set; } = null!;
+    public IList<ISeries> AnimeInfo { get; private set; } = null!;
     public List<IImportFolder> AvailableFolders { get; private set; } = null!;
 
     public LuaRenamer(ILogger<LuaRenamer> logger)
@@ -72,8 +72,8 @@ public class LuaRenamer : IRenamer
     {
         FileInfo = args.File;
         VideoInfo = args.Video;
-        AnimeInfo = args.Series.ToList();
-        EpisodeInfo = args.Episodes.ToList();
+        AnimeInfo = args.Series.Select(s => s.AnidbAnime).ToList();
+        EpisodeInfo = args.Episodes.Select(ep => ep.AnidbEpisode).ToList();
         GroupInfo = args.Groups.ToList();
         Script = args.Script;
         AvailableFolders = args.AvailableFolders.ToList();


### PR DESCRIPTION
User reported wrong anime id reported because the internal Shoko series ID was returned.