### PR TITLE
Change GH_TOKEN to use MY_GITHUB_RELEASE_PAT

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,5 +34,5 @@ jobs:
         done
     - name: Release
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.MY_GITHUB_RELEASE_PAT }}
       run: gh release create "$GITHUB_REF_NAME" ./publish/*.zip --generate-notes --verify-tag --prerelease


### PR DESCRIPTION
Updated GitHub Actions workflow to use a personal access token for releases.