### PR TITLE
Class-based builders: required-member completeness, no Build(), and a LuaContext readability pass

### DIFF
--- a/LuaBuilderGenerator/BuilderGenerator.cs
+++ b/LuaBuilderGenerator/BuilderGenerator.cs
@@ -74,17 +74,12 @@ public class BuilderGenerator : IIncrementalGenerator
 
     private static void EmitBuilder(StringBuilder sb, INamedTypeSymbol type, TypeMapper map, bool isTable)
     {
-        var className = type.Name;
         var typeFqn = type.ToDisplayString(Fq);
-        var builderName = $"{className}Builder";
+        var builderName = $"{type.Name}Builder";
 
-        sb.Append($"internal sealed class {builderName}\n{{\n");
-        sb.Append($"    private readonly {LuaTable} _t;\n\n");
-        sb.Append($"    public {builderName}({LuaTable} table)\n    {{\n        _t = table;\n");
-        if (type.GetMembers("_classidVal").OfType<IFieldSymbol>().Any(f => f.IsConst))
-            sb.Append($"        _t[\"_classid\"] = {typeFqn}._classidVal;\n");
-        sb.Append("    }\n\n");
-
+        // Collect every bound field: its property name, C# type, and the expression (in terms of the
+        // property name) that converts the typed value to what is stored in the LuaTable.
+        var members = new List<(string Name, string ParamType, string Assign)>();
         foreach (var member in type.GetMembers())
         {
             switch (member)
@@ -93,14 +88,13 @@ public class BuilderGenerator : IIncrementalGenerator
                 {
                     if (GetBool(attr, "Output"))
                         continue;
-                    var luaType = GetString(attr, 0)!;
-                    var (paramType, assign) = map.Map(luaType);
-                    EmitSetter(sb, builderName, prop.Name, paramType, $"_t[\"{prop.Name}\"] = {assign};");
+                    var (paramType, assignFmt) = map.Map(GetString(attr, 0)!);
+                    members.Add((prop.Name, paramType, string.Format(assignFmt, prop.Name)));
                     break;
                 }
                 case IMethodSymbol { MethodKind: MethodKind.Ordinary } method when GetLuaType(method) is not null:
                 {
-                    EmitSetter(sb, builderName, method.Name, LuaFunction, $"_t[\"{method.Name}\"] = v;");
+                    members.Add((method.Name, LuaFunction, method.Name));
                     break;
                 }
                 // Enum globals (EnumsTable): EnumTable<T> properties carry no [LuaType].
@@ -108,21 +102,31 @@ public class BuilderGenerator : IIncrementalGenerator
                     when GetLuaType(enumProp) is null:
                 {
                     var enumFqn = et.TypeArguments[0].ToDisplayString(Fq);
-                    EmitSetter(sb, builderName, enumProp.Name, $"{Bt}.LuaEnumRef<{enumFqn}>", $"_t[\"{enumProp.Name}\"] = v.Table;");
+                    members.Add((enumProp.Name, $"{Bt}.LuaEnumRef<{enumFqn}>", $"{enumProp.Name}.Table"));
                     break;
                 }
             }
         }
 
-        if (isTable)
-            sb.Append($"    public {Bt}.LuaRef<{typeFqn}> Build() => new(_t);\n");
-        else
-            sb.Append($"    public {LuaTable} Build() => _t;\n");
-        sb.Append("}\n\n");
-    }
+        sb.Append($"internal sealed class {builderName}\n{{\n");
+        sb.Append($"    private readonly {LuaTable} _t;\n\n");
+        sb.Append($"    public {builderName}({LuaTable} table)\n    {{\n        _t = table;\n    }}\n\n");
 
-    private static void EmitSetter(StringBuilder sb, string builderName, string name, string paramType, string body) =>
-        sb.Append($"    public {builderName} {name}({paramType} v) {{ {body} return this; }}\n");
+        // One `required` init member per field forces every field to be set in the object initializer
+        // (omitting one is a compile error), nullable fields included.
+        foreach (var m in members)
+            sb.Append($"    public required {m.ParamType} {m.Name} {{ get; init; }}\n");
+        sb.Append("\n");
+
+        // Build() flushes the typed members into the untyped LuaTable.
+        sb.Append($"    public {(isTable ? $"{Bt}.LuaRef<{typeFqn}>" : LuaTable)} Build()\n    {{\n");
+        if (type.GetMembers("_classidVal").OfType<IFieldSymbol>().Any(f => f.IsConst))
+            sb.Append($"        _t[\"_classid\"] = {typeFqn}._classidVal;\n");
+        foreach (var m in members)
+            sb.Append($"        _t[\"{m.Name}\"] = {m.Assign};\n");
+        sb.Append(isTable ? "        return new(_t);\n" : "        return _t;\n");
+        sb.Append("    }\n}\n\n");
+    }
 
     private static AttributeData? GetLuaType(ISymbol symbol) =>
         symbol.GetAttributes().FirstOrDefault(a => a.AttributeClass?.Name == "LuaTypeAttribute");
@@ -147,8 +151,9 @@ public class BuilderGenerator : IIncrementalGenerator
     }
 }
 
-/// <summary>Maps a Lua type annotation string to a C# parameter type and the assignment expression
-/// (in terms of the parameter named <c>v</c>) used to write the value into the LuaTable.</summary>
+/// <summary>Maps a Lua type annotation string to a C# member type and a <see cref="string.Format"/>
+/// template for the assignment expression that writes the typed value into the LuaTable; the single
+/// <c>{0}</c> placeholder is filled with the member name (e.g. <c>"{0}?.Table"</c>).</summary>
 internal sealed class TypeMapper(
     Dictionary<string, INamedTypeSymbol> tableByLua,
     Dictionary<string, ITypeSymbol> enumByLua)
@@ -168,7 +173,7 @@ internal sealed class TypeMapper(
         if (lua.EndsWith("[]"))
         {
             var elem = ElementType(lua.Substring(0, lua.Length - 2));
-            return ($"{Bt}.LuaArray<{elem}>{(nullable ? "?" : "")}", nullable ? "v?.Table" : "v.Table");
+            return ($"{Bt}.LuaArray<{elem}>{(nullable ? "?" : "")}", nullable ? "{0}?.Table" : "{0}.Table");
         }
 
         if (lua.StartsWith("table<") && lua.EndsWith(">"))
@@ -177,24 +182,24 @@ internal sealed class TypeMapper(
             var comma = inner.IndexOf(',');
             var k = Scalar(inner.Substring(0, comma).Trim());
             var val = Scalar(inner.Substring(comma + 1).Trim());
-            return ($"{Bt}.LuaMap<{k}, {val}>{(nullable ? "?" : "")}", nullable ? "v?.Table" : "v.Table");
+            return ($"{Bt}.LuaMap<{k}, {val}>{(nullable ? "?" : "")}", nullable ? "{0}?.Table" : "{0}.Table");
         }
 
         switch (lua)
         {
-            case "number": return ($"double{(nullable ? "?" : "")}", "v");
-            case "integer": return ($"long{(nullable ? "?" : "")}", "v");
-            case "boolean": return ($"bool{(nullable ? "?" : "")}", "v");
-            case "string": return ($"string{(nullable ? "?" : "")}", "v");
+            case "number": return ($"double{(nullable ? "?" : "")}", "{0}");
+            case "integer": return ($"long{(nullable ? "?" : "")}", "{0}");
+            case "boolean": return ($"bool{(nullable ? "?" : "")}", "{0}");
+            case "string": return ($"string{(nullable ? "?" : "")}", "{0}");
         }
 
         if (enumByLua.TryGetValue(lua, out var enumSym))
-            return ($"{enumSym.ToDisplayString(Fq)}{(nullable ? "?" : "")}", nullable ? "v?.ToString()" : "v.ToString()");
+            return ($"{enumSym.ToDisplayString(Fq)}{(nullable ? "?" : "")}", nullable ? "{0}?.ToString()" : "{0}.ToString()");
 
         if (tableByLua.TryGetValue(lua, out var tableSym))
-            return ($"{Bt}.LuaRef<{tableSym.ToDisplayString(Fq)}>{(nullable ? "?" : "")}", nullable ? "v?.Table" : "v.Table");
+            return ($"{Bt}.LuaRef<{tableSym.ToDisplayString(Fq)}>{(nullable ? "?" : "")}", nullable ? "{0}?.Table" : "{0}.Table");
 
-        return ($"object{(nullable ? "?" : "")}", "v");
+        return ($"object{(nullable ? "?" : "")}", "{0}");
     }
 
     // The generic element type of LuaArray<T> for a "T[]" field.

--- a/LuaBuilderGenerator/BuilderGenerator.cs
+++ b/LuaBuilderGenerator/BuilderGenerator.cs
@@ -77,8 +77,8 @@ public class BuilderGenerator : IIncrementalGenerator
         var typeFqn = type.ToDisplayString(Fq);
         var builderName = $"{type.Name}Builder";
 
-        // Collect every bound field: its property name, C# type, and the expression (in terms of the
-        // property name) that converts the typed value to what is stored in the LuaTable.
+        // Collect every bound field: its member name, C# type, and the expression (in terms of the
+        // init accessor's `value`) that converts the typed value to what is stored in the LuaTable.
         var members = new List<(string Name, string ParamType, string Assign)>();
         foreach (var member in type.GetMembers())
         {
@@ -89,12 +89,12 @@ public class BuilderGenerator : IIncrementalGenerator
                     if (GetBool(attr, "Output"))
                         continue;
                     var (paramType, assignFmt) = map.Map(GetString(attr, 0)!);
-                    members.Add((prop.Name, paramType, string.Format(assignFmt, prop.Name)));
+                    members.Add((prop.Name, paramType, string.Format(assignFmt, "value")));
                     break;
                 }
                 case IMethodSymbol { MethodKind: MethodKind.Ordinary } method when GetLuaType(method) is not null:
                 {
-                    members.Add((method.Name, LuaFunction, method.Name));
+                    members.Add((method.Name, LuaFunction, "value"));
                     break;
                 }
                 // Enum globals (EnumsTable): EnumTable<T> properties carry no [LuaType].
@@ -102,7 +102,7 @@ public class BuilderGenerator : IIncrementalGenerator
                     when GetLuaType(enumProp) is null:
                 {
                     var enumFqn = et.TypeArguments[0].ToDisplayString(Fq);
-                    members.Add((enumProp.Name, $"{Bt}.LuaEnumRef<{enumFqn}>", $"{enumProp.Name}.Table"));
+                    members.Add((enumProp.Name, $"{Bt}.LuaEnumRef<{enumFqn}>", "value.Table"));
                     break;
                 }
             }
@@ -110,22 +110,27 @@ public class BuilderGenerator : IIncrementalGenerator
 
         sb.Append($"internal sealed class {builderName}\n{{\n");
         sb.Append($"    private readonly {LuaTable} _t;\n\n");
-        sb.Append($"    public {builderName}({LuaTable} table)\n    {{\n        _t = table;\n    }}\n\n");
-
-        // One `required` init member per field forces every field to be set in the object initializer
-        // (omitting one is a compile error), nullable fields included.
-        foreach (var m in members)
-            sb.Append($"    public required {m.ParamType} {m.Name} {{ get; init; }}\n");
-        sb.Append("\n");
-
-        // Build() flushes the typed members into the untyped LuaTable.
-        sb.Append($"    public {(isTable ? $"{Bt}.LuaRef<{typeFqn}>" : LuaTable)} Build()\n    {{\n");
+        sb.Append($"    public {builderName}({LuaTable} table)\n    {{\n        _t = table;\n");
         if (type.GetMembers("_classidVal").OfType<IFieldSymbol>().Any(f => f.IsConst))
             sb.Append($"        _t[\"_classid\"] = {typeFqn}._classidVal;\n");
+        sb.Append("    }\n\n");
+
+        // One `required` init member per field writes straight into the LuaTable; `required` forces
+        // every field to be set in the object initializer (omitting one is a compile error), nullable
+        // fields included.
         foreach (var m in members)
-            sb.Append($"        _t[\"{m.Name}\"] = {m.Assign};\n");
-        sb.Append(isTable ? "        return new(_t);\n" : "        return _t;\n");
-        sb.Append("    }\n}\n\n");
+            sb.Append($"    public required {m.ParamType} {m.Name} {{ init => _t[\"{m.Name}\"] = {m.Assign}; }}\n");
+
+        // A typed-handle implicit conversion replaces Build() for table builders, so a populated
+        // builder is the LuaRef<T>. Root builders mutate the env table in place and are used as a
+        // statement, so they need no conversion.
+        if (isTable)
+        {
+            sb.Append("\n");
+            sb.Append($"    public static implicit operator {Bt}.LuaRef<{typeFqn}>({builderName} b) => new(b._t);\n");
+        }
+
+        sb.Append("}\n\n");
     }
 
     private static AttributeData? GetLuaType(ISymbol symbol) =>

--- a/LuaBuilderGeneratorTests/BuilderGeneratorTests.cs
+++ b/LuaBuilderGeneratorTests/BuilderGeneratorTests.cs
@@ -77,65 +77,58 @@ public class BuilderGeneratorTests
     [TestMethod]
     public void ScalarMapping()
     {
-        AssertContains("public required double rating { get; init; }");
-        AssertContains("public required long id { get; init; }");
-        AssertContains("public required bool restricted { get; init; }");
-        AssertContains("public required string preferredname { get; init; }");
+        // Each field is a `required` init member that writes straight into the LuaTable.
+        AssertContains("public required double rating { init => _t[\"rating\"] = value; }");
+        AssertContains("public required long id { init => _t[\"id\"] = value; }");
+        AssertContains("public required bool restricted { init => _t[\"restricted\"] = value; }");
+        AssertContains("public required string preferredname { init => _t[\"preferredname\"] = value; }");
         // Nullable string (PreferredTitle-fed field corrected to string|nil).
-        AssertContains("public required string? name { get; init; }");
-        // Build() flushes the typed scalar straight into the LuaTable.
-        AssertContains("_t[\"rating\"] = rating;");
+        AssertContains("public required string? name { init => _t[\"name\"] = value; }");
     }
 
     [TestMethod]
     public void EnumMapping()
     {
-        // Member accepts the CLR enum; Build() stringifies to match the enum-name Lua tables.
-        AssertContains("public required global::Shoko.Abstractions.Metadata.Enums.AnimeType type { get; init; }");
-        AssertContains("_t[\"type\"] = type.ToString();");
+        // Member accepts the CLR enum; the setter stringifies to match the enum-name Lua tables.
+        AssertContains("public required global::Shoko.Abstractions.Metadata.Enums.AnimeType type { init => _t[\"type\"] = value.ToString(); }");
     }
 
     [TestMethod]
     public void NestedAndNullableMapping()
     {
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.DateTimeTable>? airdate { get; init; }");
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.ReleaseGroupTable>? releasegroup { get; init; }");
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.AnimeTable> mainanime { get; init; }");
-        // Nullable ref unwraps with ?.Table, non-null with .Table.
-        AssertContains("_t[\"airdate\"] = airdate?.Table;");
-        AssertContains("_t[\"mainanime\"] = mainanime.Table;");
+        // Nullable ref unwraps with value?.Table, non-null with value.Table.
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.DateTimeTable>? airdate { init => _t[\"airdate\"] = value?.Table; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.ReleaseGroupTable>? releasegroup { init => _t[\"releasegroup\"] = value?.Table; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.AnimeTable> mainanime { init => _t[\"mainanime\"] = value.Table; }");
     }
 
     [TestMethod]
     public void ArrayMapping()
     {
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.TitleTable>> titles { get; init; }");
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<string> studios { get; init; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.TitleTable>> titles { init => _t[\"titles\"] = value.Table; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<string> studios { init => _t[\"studios\"] = value.Table; }");
         // Enum array (Language[]) maps to an enum-typed LuaArray.
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<global::Shoko.Abstractions.Metadata.Enums.TitleLanguage> sublanguages { get; init; }");
-        AssertContains("_t[\"titles\"] = titles.Table;");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<global::Shoko.Abstractions.Metadata.Enums.TitleLanguage> sublanguages { init => _t[\"sublanguages\"] = value.Table; }");
     }
 
     [TestMethod]
     public void MapMapping()
     {
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaMap<global::Shoko.Abstractions.Metadata.Enums.EpisodeType, long> episodecounts { get; init; }");
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaMap<string, string> illegal_chars_map { get; init; }");
-        AssertContains("_t[\"episodecounts\"] = episodecounts.Table;");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaMap<global::Shoko.Abstractions.Metadata.Enums.EpisodeType, long> episodecounts { init => _t[\"episodecounts\"] = value.Table; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaMap<string, string> illegal_chars_map { init => _t[\"illegal_chars_map\"] = value.Table; }");
     }
 
     [TestMethod]
     public void FunctionMapping()
     {
-        AssertContains("public required global::NLua.LuaFunction getname { get; init; }");
-        AssertContains("public required global::NLua.LuaFunction log { get; init; }");
-        AssertContains("_t[\"getname\"] = getname;");
+        AssertContains("public required global::NLua.LuaFunction getname { init => _t[\"getname\"] = value; }");
+        AssertContains("public required global::NLua.LuaFunction log { init => _t[\"log\"] = value; }");
     }
 
     [TestMethod]
     public void ClassidAutoSet()
     {
-        // Tables carrying a _classidVal const get _classid auto-set at the top of Build().
+        // Tables carrying a _classidVal const get _classid auto-set in the constructor.
         AssertContains("_t[\"_classid\"] = global::LuaRenamer.LuaEnv.AnimeTable._classidVal;");
         // A table without _classidVal must not reference a _classidVal member.
         Assert.IsFalse(_source.Contains("global::LuaRenamer.LuaEnv.TitleTable._classidVal", StringComparison.Ordinal),
@@ -155,15 +148,16 @@ public class BuilderGeneratorTests
     }
 
     [TestMethod]
-    public void EnumGlobalsAndBuildReturns()
+    public void EnumGlobalsAndHandleConversions()
     {
         // Enum global member: Lua name "Language" resolves to CLR TitleLanguage via EnumsTable.
-        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaEnumRef<global::Shoko.Abstractions.Metadata.Enums.TitleLanguage> Language { get; init; }");
-        AssertContains("_t[\"Language\"] = Language.Table;");
-        // Root builders return the underlying LuaTable; table builders return a typed LuaRef.
-        AssertContains("public global::NLua.LuaTable Build()");
-        AssertContains("return _t;");
-        AssertContains("public global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.AnimeTable> Build()");
-        AssertContains("return new(_t);");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaEnumRef<global::Shoko.Abstractions.Metadata.Enums.TitleLanguage> Language { init => _t[\"Language\"] = value.Table; }");
+        // Table builders implicitly convert to their typed handle (replacing Build()).
+        AssertContains("public static implicit operator global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.AnimeTable>(AnimeTableBuilder b) => new(b._t);");
+        // Root builders mutate the env table in place: no handle, no conversion.
+        Assert.IsFalse(_source.Contains("LuaRef<global::LuaRenamer.LuaEnv.EnvTable>", StringComparison.Ordinal),
+            "EnvTableBuilder is a root builder and must not expose a LuaRef handle.");
+        Assert.IsFalse(_source.Contains("LuaRef<global::LuaRenamer.LuaEnv.EnumsTable>", StringComparison.Ordinal),
+            "EnumsTableBuilder is a root builder and must not expose a LuaRef handle.");
     }
 }

--- a/LuaBuilderGeneratorTests/BuilderGeneratorTests.cs
+++ b/LuaBuilderGeneratorTests/BuilderGeneratorTests.cs
@@ -77,56 +77,65 @@ public class BuilderGeneratorTests
     [TestMethod]
     public void ScalarMapping()
     {
-        AssertContains("public AnimeTableBuilder rating(double v) { _t[\"rating\"] = v; return this; }");
-        AssertContains("public AnimeTableBuilder id(long v) { _t[\"id\"] = v; return this; }");
-        AssertContains("public AnimeTableBuilder restricted(bool v) { _t[\"restricted\"] = v; return this; }");
-        AssertContains("public AnimeTableBuilder preferredname(string v) { _t[\"preferredname\"] = v; return this; }");
+        AssertContains("public required double rating { get; init; }");
+        AssertContains("public required long id { get; init; }");
+        AssertContains("public required bool restricted { get; init; }");
+        AssertContains("public required string preferredname { get; init; }");
         // Nullable string (PreferredTitle-fed field corrected to string|nil).
-        AssertContains("public GroupTableBuilder name(string? v) { _t[\"name\"] = v; return this; }");
+        AssertContains("public required string? name { get; init; }");
+        // Build() flushes the typed scalar straight into the LuaTable.
+        AssertContains("_t[\"rating\"] = rating;");
     }
 
     [TestMethod]
     public void EnumMapping()
     {
-        // Setter accepts the CLR enum; builder stringifies to match the enum-name Lua tables.
-        AssertContains("public AnimeTableBuilder type(global::Shoko.Abstractions.Metadata.Enums.AnimeType v) { _t[\"type\"] = v.ToString(); return this; }");
+        // Member accepts the CLR enum; Build() stringifies to match the enum-name Lua tables.
+        AssertContains("public required global::Shoko.Abstractions.Metadata.Enums.AnimeType type { get; init; }");
+        AssertContains("_t[\"type\"] = type.ToString();");
     }
 
     [TestMethod]
     public void NestedAndNullableMapping()
     {
-        AssertContains("public AnimeTableBuilder airdate(global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.DateTimeTable>? v) { _t[\"airdate\"] = v?.Table; return this; }");
-        AssertContains("public AniDbTableBuilder releasegroup(global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.ReleaseGroupTable>? v) { _t[\"releasegroup\"] = v?.Table; return this; }");
-        AssertContains("public GroupTableBuilder mainanime(global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.AnimeTable> v) { _t[\"mainanime\"] = v.Table; return this; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.DateTimeTable>? airdate { get; init; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.ReleaseGroupTable>? releasegroup { get; init; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.AnimeTable> mainanime { get; init; }");
+        // Nullable ref unwraps with ?.Table, non-null with .Table.
+        AssertContains("_t[\"airdate\"] = airdate?.Table;");
+        AssertContains("_t[\"mainanime\"] = mainanime.Table;");
     }
 
     [TestMethod]
     public void ArrayMapping()
     {
-        AssertContains("public AnimeTableBuilder titles(global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.TitleTable>> v) { _t[\"titles\"] = v.Table; return this; }");
-        AssertContains("public AnimeTableBuilder studios(global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<string> v) { _t[\"studios\"] = v.Table; return this; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.TitleTable>> titles { get; init; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<string> studios { get; init; }");
         // Enum array (Language[]) maps to an enum-typed LuaArray.
-        AssertContains("public AniDbMediaTableBuilder sublanguages(global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<global::Shoko.Abstractions.Metadata.Enums.TitleLanguage> v) { _t[\"sublanguages\"] = v.Table; return this; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaArray<global::Shoko.Abstractions.Metadata.Enums.TitleLanguage> sublanguages { get; init; }");
+        AssertContains("_t[\"titles\"] = titles.Table;");
     }
 
     [TestMethod]
     public void MapMapping()
     {
-        AssertContains("public AnimeTableBuilder episodecounts(global::LuaRenamer.LuaEnv.BaseTypes.LuaMap<global::Shoko.Abstractions.Metadata.Enums.EpisodeType, long> v) { _t[\"episodecounts\"] = v.Table; return this; }");
-        AssertContains("public EnvTableBuilder illegal_chars_map(global::LuaRenamer.LuaEnv.BaseTypes.LuaMap<string, string> v) { _t[\"illegal_chars_map\"] = v.Table; return this; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaMap<global::Shoko.Abstractions.Metadata.Enums.EpisodeType, long> episodecounts { get; init; }");
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaMap<string, string> illegal_chars_map { get; init; }");
+        AssertContains("_t[\"episodecounts\"] = episodecounts.Table;");
     }
 
     [TestMethod]
     public void FunctionMapping()
     {
-        AssertContains("public AnimeTableBuilder getname(global::NLua.LuaFunction v) { _t[\"getname\"] = v; return this; }");
-        AssertContains("public EnvTableBuilder log(global::NLua.LuaFunction v) { _t[\"log\"] = v; return this; }");
+        AssertContains("public required global::NLua.LuaFunction getname { get; init; }");
+        AssertContains("public required global::NLua.LuaFunction log { get; init; }");
+        AssertContains("_t[\"getname\"] = getname;");
     }
 
     [TestMethod]
     public void ClassidAutoSet()
     {
-        // Tables carrying a _classidVal const get _classid auto-set in the builder constructor.
+        // Tables carrying a _classidVal const get _classid auto-set at the top of Build().
         AssertContains("_t[\"_classid\"] = global::LuaRenamer.LuaEnv.AnimeTable._classidVal;");
         // A table without _classidVal must not reference a _classidVal member.
         Assert.IsFalse(_source.Contains("global::LuaRenamer.LuaEnv.TitleTable._classidVal", StringComparison.Ordinal),
@@ -136,22 +145,25 @@ public class BuilderGeneratorTests
     [TestMethod]
     public void OutputFieldsAreSkipped()
     {
-        // filename/destination/subfolder are Output = true and have no generated setter.
-        Assert.IsFalse(_source.Contains("EnvTableBuilder filename(", StringComparison.Ordinal),
-            "filename is an Output field and must not get a setter.");
-        Assert.IsFalse(_source.Contains("EnvTableBuilder destination(", StringComparison.Ordinal),
-            "destination is an Output field and must not get a setter.");
-        Assert.IsFalse(_source.Contains("EnvTableBuilder subfolder(", StringComparison.Ordinal),
-            "subfolder is an Output field and must not get a setter.");
+        // filename/destination/subfolder are Output = true and get no generated member at all.
+        Assert.IsFalse(_source.Contains("filename", StringComparison.Ordinal),
+            "filename is an Output field and must not get a member.");
+        Assert.IsFalse(_source.Contains("destination", StringComparison.Ordinal),
+            "destination is an Output field and must not get a member.");
+        Assert.IsFalse(_source.Contains("subfolder", StringComparison.Ordinal),
+            "subfolder is an Output field and must not get a member.");
     }
 
     [TestMethod]
     public void EnumGlobalsAndBuildReturns()
     {
-        // Enum global setter: Lua name "Language" resolves to CLR TitleLanguage via EnumsTable.
-        AssertContains("public EnumsTableBuilder Language(global::LuaRenamer.LuaEnv.BaseTypes.LuaEnumRef<global::Shoko.Abstractions.Metadata.Enums.TitleLanguage> v) { _t[\"Language\"] = v.Table; return this; }");
+        // Enum global member: Lua name "Language" resolves to CLR TitleLanguage via EnumsTable.
+        AssertContains("public required global::LuaRenamer.LuaEnv.BaseTypes.LuaEnumRef<global::Shoko.Abstractions.Metadata.Enums.TitleLanguage> Language { get; init; }");
+        AssertContains("_t[\"Language\"] = Language.Table;");
         // Root builders return the underlying LuaTable; table builders return a typed LuaRef.
-        AssertContains("public global::NLua.LuaTable Build() => _t;");
-        AssertContains("public global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.AnimeTable> Build() => new(_t);");
+        AssertContains("public global::NLua.LuaTable Build()");
+        AssertContains("return _t;");
+        AssertContains("public global::LuaRenamer.LuaEnv.BaseTypes.LuaRef<global::LuaRenamer.LuaEnv.AnimeTable> Build()");
+        AssertContains("return new(_t);");
     }
 }

--- a/LuaRenamer/LuaContext.cs
+++ b/LuaRenamer/LuaContext.cs
@@ -14,6 +14,7 @@ using Shoko.Abstractions.Metadata;
 using Shoko.Abstractions.Metadata.Anidb;
 using Shoko.Abstractions.Metadata.Enums;
 using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.Metadata.Tmdb;
 using Shoko.Abstractions.Video;
 using Shoko.Abstractions.Video.Enums;
 using Shoko.Abstractions.Video.Media;
@@ -34,6 +35,9 @@ public class LuaContext : Lua
     private readonly Dictionary<(Type, int), LuaTable> _tableCache = new();
     private readonly IShokoSeries _primarySeries;
     private readonly IShokoEpisode _primaryEpisode;
+
+    // The shared title-resolver closure for this env build; set by CreateLuaEnv before any *ToTable runs.
+    private LuaFunction _getName = null!;
 
 
     #region Sandbox
@@ -183,29 +187,29 @@ public class LuaContext : Lua
         var env = (LuaTable)DoString(BaseEnv)[0];
         runSandboxed.Call(_luaLinqText, env);
         runSandboxed.Call(_luaUtilsText, env);
-        var getName = (LuaFunction)runSandboxed.Call(GetNameFunction, env)[1];
+        _getName = (LuaFunction)runSandboxed.Call(GetNameFunction, env)[1];
 
         var animes = _args.Series
             .OrderBy(s => s.AnidbAnimeID != _primarySeries.AnidbAnimeID)
             .ThenBy(s => s.AnidbAnimeID)
-            .Select(series => AnimeToTable(series.AnidbAnime, false, getName)).ToList();
+            .Select(series => AnimeToTable(series.AnidbAnime, false)).ToList();
         var episodes = _args.Episodes
             .OrderBy(e => e.AnidbEpisodeID != _primaryEpisode.AnidbEpisodeID)
             .ThenBy(e => e.AnidbEpisode.SeriesID)
             .ThenBy(e => e.AnidbEpisode.Type == EpisodeType.Other ? int.MinValue : (int)e.AnidbEpisode.Type)
             .ThenBy(e => e.AnidbEpisode.EpisodeNumber)
-            .Select(e => EpisodeToTable(e.AnidbEpisode, getName)).ToList();
+            .Select(e => EpisodeToTable(e.AnidbEpisode)).ToList();
         var groups = _args.Groups
             .OrderBy(g => g.MainSeriesID != _primarySeries.AnidbAnimeID)
-            .Select(g => GroupToTable(g, getName)).ToList();
+            .Select(GroupToTable).ToList();
 
         _ = new EnvTableBuilder(env)
         {
-            logdebug = RegisterFunction("_", this, LogDebugMethod),
-            log = RegisterFunction("_", this, LogMethod),
-            logwarn = RegisterFunction("_", this, LogWarnMethod),
-            logerror = RegisterFunction("_", this, LogErrorMethod),
-            episode_numbers = RegisterFunction("_", this, EpNumsMethod),
+            logdebug = Bind(LogDebugMethod),
+            log = Bind(LogMethod),
+            logwarn = Bind(LogWarnMethod),
+            logerror = Bind(LogErrorMethod),
+            episode_numbers = Bind(EpNumsMethod),
             replace_illegal_chars = _args.Configuration.ReplaceIllegalCharacters,
             remove_illegal_chars = _args.Configuration.RemoveIllegalCharacters,
             use_existing_anime_location = _args.Configuration.UseExistingAnimeLocation,
@@ -220,7 +224,7 @@ public class LuaContext : Lua
             importfolders = ArrayOf(_args.AvailableFolders.Select(ImportFolderToTable)),
             groups = ArrayOf(groups),
             group = groups.Count > 0 ? groups[0] : null,
-            tmdb = TmdbToTable(getName),
+            tmdb = TmdbToTable(),
         };
 
         _ = new EnumsTableBuilder(env)
@@ -249,42 +253,43 @@ public class LuaContext : Lua
     private LuaMap<string, string> ReplaceMapToTable()
         => MapOf(FilePathCleaner.ReplaceMapDefaults.Select(kvp => (kvp.Key, kvp.Value)));
 
-    private LuaRef<GroupTable> GroupToTable(IShokoGroup group, LuaFunction getName) =>
+    private LuaRef<GroupTable> GroupToTable(IShokoGroup group) =>
         new GroupTableBuilder(GetNewTable())
         {
             name = string.IsNullOrWhiteSpace(group.PreferredTitle?.Value) ? null : group.PreferredTitle?.Value,
-            mainanime = AnimeToTable(group.MainSeries.AnidbAnime, false, getName),
-            animes = ArrayOf(group.AllSeries.Select(a => AnimeToTable(a.AnidbAnime, false, getName))),
+            mainanime = AnimeToTable(group.MainSeries.AnidbAnime, false),
+            animes = ArrayOf(group.AllSeries.Select(a => AnimeToTable(a.AnidbAnime, false))),
         };
 
-    private LuaRef<AnimeTable> AnimeToTable(IAnidbAnime anime, bool ignoreRelations, LuaFunction getName)
+    private LuaRef<AnimeTable> AnimeToTable(IAnidbAnime anime, bool ignoreRelations)
     {
         ArgumentNullException.ThrowIfNull(anime);
-        if (GetCachedOrNewTable((typeof(IAnidbAnime), anime.ID), out var animeTable))
-            return new LuaRef<AnimeTable>(animeTable);
-        var series = anime.ShokoSeries.FirstOrDefault();
-        return new AnimeTableBuilder(animeTable)
+        return Cached<IAnidbAnime, AnimeTable>(anime.ID, tbl =>
         {
-            airdate = DateTimeToTable(anime.AirDate?.ToDateTime()),
-            enddate = DateTimeToTable(anime.EndDate?.ToDateTime()),
-            rating = anime.Rating,
-            restricted = anime.Restricted,
-            type = anime.Type,
-            preferredname = string.IsNullOrWhiteSpace(series?.Title) ? anime.Title : series.Title,
-            defaultname = string.IsNullOrWhiteSpace(series?.DefaultTitle.Value) ? anime.DefaultTitle.Value : series.DefaultTitle.Value,
-            id = anime.ID,
-            titles = ArrayOf(anime.Titles.OrderBy(t => t.Value).Select(TitleToTable)),
-            getname = getName,
-            studios = ArrayOf(anime.Studios.Select(st => st.Name)),
-            episodecounts = MapOf(Enum.GetValues<EpisodeType>().Select(ep => (ep, (long)anime.EpisodeCounts[ep]))),
-            relations = ArrayOf(ignoreRelations
-                ? Enumerable.Empty<LuaRef<RelationTable>>()
-                : anime.RelatedSeries.Where(r => r.Related is not null && r.Related.ID != anime.ID)
-                    .Select(r => RelationToTable(r, getName))),
-            tags = ArrayOf(anime.Tags.Select(t => t.Name)),
-            customtags = ArrayOf(series?.Tags.Select(t => t.Name) ?? []),
-            seasons = ArrayOf(anime.YearlySeasons.Select(SeasonToTable)),
-        };
+            var series = anime.ShokoSeries.FirstOrDefault();
+            return new AnimeTableBuilder(tbl)
+            {
+                airdate = DateTimeToTable(anime.AirDate?.ToDateTime()),
+                enddate = DateTimeToTable(anime.EndDate?.ToDateTime()),
+                rating = anime.Rating,
+                restricted = anime.Restricted,
+                type = anime.Type,
+                preferredname = string.IsNullOrWhiteSpace(series?.Title) ? anime.Title : series.Title,
+                defaultname = string.IsNullOrWhiteSpace(series?.DefaultTitle.Value) ? anime.DefaultTitle.Value : series.DefaultTitle.Value,
+                id = anime.ID,
+                titles = ArrayOf(anime.Titles.OrderBy(t => t.Value).Select(TitleToTable)),
+                getname = _getName,
+                studios = ArrayOf(anime.Studios.Select(st => st.Name)),
+                episodecounts = MapOf(Enum.GetValues<EpisodeType>().Select(ep => (ep, (long)anime.EpisodeCounts[ep]))),
+                relations = ArrayOf(ignoreRelations
+                    ? Enumerable.Empty<LuaRef<RelationTable>>()
+                    : anime.RelatedSeries.Where(r => r.Related is not null && r.Related.ID != anime.ID)
+                        .Select(RelationToTable)),
+                tags = ArrayOf(anime.Tags.Select(t => t.Name)),
+                customtags = ArrayOf(series?.Tags.Select(t => t.Name) ?? []),
+                seasons = ArrayOf(anime.YearlySeasons.Select(SeasonToTable)),
+            };
+        });
     }
 
     private LuaRef<SeasonTable> SeasonToTable((int Year, YearlySeason Season) season) =>
@@ -294,10 +299,10 @@ public class LuaContext : Lua
             season = season.Season,
         };
 
-    private LuaRef<RelationTable> RelationToTable(IRelatedMetadata<ISeries, ISeries> relation, LuaFunction getName) =>
+    private LuaRef<RelationTable> RelationToTable(IRelatedMetadata<ISeries, ISeries> relation) =>
         new RelationTableBuilder(GetNewTable())
         {
-            anime = AnimeToTable((relation.Related as IAnidbAnime)!, true, getName),
+            anime = AnimeToTable((relation.Related as IAnidbAnime)!, true),
             type = relation.RelationType,
         };
 
@@ -333,11 +338,8 @@ public class LuaContext : Lua
         };
     }
 
-    private LuaRef<EpisodeTable> EpisodeToTable(IAnidbEpisode episode, LuaFunction getName)
-    {
-        if (GetCachedOrNewTable((typeof(IAnidbEpisode), episode.ID), out var epTable))
-            return new LuaRef<EpisodeTable>(epTable);
-        return new EpisodeTableBuilder(epTable)
+    private LuaRef<EpisodeTable> EpisodeToTable(IAnidbEpisode episode) =>
+        Cached<IAnidbEpisode, EpisodeTable>(episode.ID, tbl => new EpisodeTableBuilder(tbl)
         {
             duration = (long)episode.Runtime.TotalSeconds,
             number = episode.EpisodeNumber,
@@ -346,10 +348,9 @@ public class LuaContext : Lua
             animeid = episode.SeriesID,
             id = episode.ID,
             titles = ArrayOf(episode.Titles.OrderBy(t => t.Value).Select(TitleToTable)),
-            getname = getName,
+            getname = _getName,
             prefix = Utils.EpPrefix[episode.Type],
-        };
-    }
+        });
 
     private LuaRef<TitleTable> TitleToTable(ITitle title) =>
         new TitleTableBuilder(GetNewTable())
@@ -380,18 +381,14 @@ public class LuaContext : Lua
             importfolder = ImportFolderToTable(file.ManagedFolder),
         };
 
-    private LuaRef<ImportFolderTable> ImportFolderToTable(IManagedFolder folder)
-    {
-        if (GetCachedOrNewTable((typeof(IManagedFolder), folder.ID), out var importTable))
-            return new LuaRef<ImportFolderTable>(importTable);
-        return new ImportFolderTableBuilder(importTable)
+    private LuaRef<ImportFolderTable> ImportFolderToTable(IManagedFolder folder) =>
+        Cached<IManagedFolder, ImportFolderTable>(folder.ID, tbl => new ImportFolderTableBuilder(tbl)
         {
             id = folder.ID,
             name = folder.Name,
             location = folder.Path,
             type = folder.DropFolderType,
-        };
-    }
+        });
 
     private LuaRef<MediaTable>? MediaInfoToTable(IMediaInfo? mediaInfo)
     {
@@ -399,33 +396,37 @@ public class LuaContext : Lua
             return null;
         return new MediaTableBuilder(GetNewTable())
         {
-            video = mediaInfo.VideoStream is { } video
-                ? (LuaRef<VideoTable>)new VideoTableBuilder(GetNewTable())
-                {
-                    height = video.Height,
-                    width = video.Width,
-                    codec = video.Codec.Simplified,
-                    res = video.Resolution,
-                    bitrate = video.BitRate,
-                    bitdepth = video.BitDepth,
-                    framerate = (double)video.FrameRate,
-                }
-                : null,
+            video = mediaInfo.VideoStream is { } video ? VideoToTable(video) : null,
             chaptered = mediaInfo.Chapters.Any(),
             duration = (long)mediaInfo.Duration.TotalSeconds,
             bitrate = mediaInfo.BitRate,
             sublanguages = ArrayOf(mediaInfo.TextStreams.Select(s => s.Language.ToString())),
-            audio = ArrayOf(mediaInfo.AudioStreams.Select(a => (LuaRef<AudioTable>)new AudioTableBuilder(GetNewTable())
-            {
-                compressionmode = a.CompressionMode,
-                channels = !string.IsNullOrWhiteSpace(a.ChannelLayout) && a.ChannelLayout.Contains("LFE") ? a.Channels - 1 + 0.1 : a.Channels,
-                samplingrate = a.SamplingRate,
-                codec = a.Codec.Simplified,
-                language = a.Language.ToString(),
-                title = a.Title,
-            })),
+            audio = ArrayOf(mediaInfo.AudioStreams.Select(AudioToTable)),
         };
     }
+
+    private LuaRef<VideoTable> VideoToTable(IVideoStream video) =>
+        new VideoTableBuilder(GetNewTable())
+        {
+            height = video.Height,
+            width = video.Width,
+            codec = video.Codec.Simplified,
+            res = video.Resolution,
+            bitrate = video.BitRate,
+            bitdepth = video.BitDepth,
+            framerate = (double)video.FrameRate,
+        };
+
+    private LuaRef<AudioTable> AudioToTable(IAudioStream audio) =>
+        new AudioTableBuilder(GetNewTable())
+        {
+            compressionmode = audio.CompressionMode,
+            channels = !string.IsNullOrWhiteSpace(audio.ChannelLayout) && audio.ChannelLayout.Contains("LFE") ? audio.Channels - 1 + 0.1 : audio.Channels,
+            samplingrate = audio.SamplingRate,
+            codec = audio.Codec.Simplified,
+            language = audio.Language.ToString(),
+            title = audio.Title,
+        };
 
     private LuaRef<DateTimeTable>? DateTimeToTable(DateTime? dateTime)
     {
@@ -445,50 +446,59 @@ public class LuaContext : Lua
         };
     }
 
-    private LuaRef<TmdbTable> TmdbToTable(LuaFunction getName) =>
+    private LuaRef<TmdbTable> TmdbToTable() =>
         new TmdbTableBuilder(GetNewTable())
         {
-            movies = ArrayOf(_args.Series[0].TmdbMovies.Select(m => (LuaRef<TmdbMovieTable>)new TmdbMovieTableBuilder(GetNewTable())
-            {
-                id = m.ID,
-                titles = ArrayOf(m.Titles.Select(TitleToTable)),
-                defaultname = string.IsNullOrWhiteSpace(m.DefaultTitle?.Value) ? null : m.DefaultTitle?.Value,
-                preferredname = string.IsNullOrWhiteSpace(m.PreferredTitle?.Value) ? null : m.PreferredTitle?.Value,
-                rating = m.Rating,
-                restricted = m.Restricted,
-                studios = ArrayOf(m.Studios.Select(s => s.Name)),
-                airdate = DateTimeToTable(m.ReleaseDate),
-                getname = getName,
-            })),
-            shows = ArrayOf(_args.Series[0].TmdbShows.Select(s => (LuaRef<TmdbShowTable>)new TmdbShowTableBuilder(GetNewTable())
-            {
-                id = s.ID,
-                titles = ArrayOf(s.Titles.Select(TitleToTable)),
-                defaultname = string.IsNullOrWhiteSpace(s.DefaultTitle?.Value) ? null : s.DefaultTitle?.Value,
-                preferredname = string.IsNullOrWhiteSpace(s.PreferredTitle?.Value) ? null : s.PreferredTitle?.Value,
-                rating = s.Rating,
-                restricted = s.Restricted,
-                studios = ArrayOf(s.Studios.Select(st => st.Name)),
-                episodecount = s.EpisodeCounts.Episodes,
-                airdate = DateTimeToTable(s.AirDate?.ToDateTime()),
-                enddate = DateTimeToTable(s.EndDate?.ToDateTime()),
-                getname = getName,
-                seasons = ArrayOf(s.YearlySeasons.Select(SeasonToTable)),
-            })),
+            movies = ArrayOf(_args.Series[0].TmdbMovies.Select(TmdbMovieToTable)),
+            shows = ArrayOf(_args.Series[0].TmdbShows.Select(TmdbShowToTable)),
             episodes = ArrayOf(_args.Episodes.Where(e => e.SeriesID == _primarySeries.ID)
-                .SelectMany(e => e.TmdbEpisodes.Select(e2 => (LuaRef<TmdbEpisodeTable>)new TmdbEpisodeTableBuilder(GetNewTable())
-                {
-                    showid = e2.SeriesID,
-                    id = e2.ID,
-                    titles = ArrayOf(e2.Titles.Select(TitleToTable)),
-                    defaultname = string.IsNullOrWhiteSpace(e2.DefaultTitle?.Value) ? null : e2.DefaultTitle?.Value,
-                    preferredname = string.IsNullOrWhiteSpace(e2.PreferredTitle?.Value) ? null : e2.PreferredTitle?.Value,
-                    type = e2.Type,
-                    number = e2.EpisodeNumber,
-                    seasonnumber = e2.SeasonNumber,
-                    airdate = DateTimeToTable(e2.AirDateWithTime),
-                    getname = getName,
-                }))),
+                .SelectMany(e => e.TmdbEpisodes.Select(TmdbEpisodeToTable))),
+        };
+
+    private LuaRef<TmdbMovieTable> TmdbMovieToTable(ITmdbMovie movie) =>
+        new TmdbMovieTableBuilder(GetNewTable())
+        {
+            id = movie.ID,
+            titles = ArrayOf(movie.Titles.Select(TitleToTable)),
+            defaultname = string.IsNullOrWhiteSpace(movie.DefaultTitle?.Value) ? null : movie.DefaultTitle?.Value,
+            preferredname = string.IsNullOrWhiteSpace(movie.PreferredTitle?.Value) ? null : movie.PreferredTitle?.Value,
+            rating = movie.Rating,
+            restricted = movie.Restricted,
+            studios = ArrayOf(movie.Studios.Select(s => s.Name)),
+            airdate = DateTimeToTable(movie.ReleaseDate),
+            getname = _getName,
+        };
+
+    private LuaRef<TmdbShowTable> TmdbShowToTable(ITmdbShow show) =>
+        new TmdbShowTableBuilder(GetNewTable())
+        {
+            id = show.ID,
+            titles = ArrayOf(show.Titles.Select(TitleToTable)),
+            defaultname = string.IsNullOrWhiteSpace(show.DefaultTitle?.Value) ? null : show.DefaultTitle?.Value,
+            preferredname = string.IsNullOrWhiteSpace(show.PreferredTitle?.Value) ? null : show.PreferredTitle?.Value,
+            rating = show.Rating,
+            restricted = show.Restricted,
+            studios = ArrayOf(show.Studios.Select(st => st.Name)),
+            episodecount = show.EpisodeCounts.Episodes,
+            airdate = DateTimeToTable(show.AirDate?.ToDateTime()),
+            enddate = DateTimeToTable(show.EndDate?.ToDateTime()),
+            getname = _getName,
+            seasons = ArrayOf(show.YearlySeasons.Select(SeasonToTable)),
+        };
+
+    private LuaRef<TmdbEpisodeTable> TmdbEpisodeToTable(ITmdbEpisode episode) =>
+        new TmdbEpisodeTableBuilder(GetNewTable())
+        {
+            showid = episode.SeriesID,
+            id = episode.ID,
+            titles = ArrayOf(episode.Titles.Select(TitleToTable)),
+            defaultname = string.IsNullOrWhiteSpace(episode.DefaultTitle?.Value) ? null : episode.DefaultTitle?.Value,
+            preferredname = string.IsNullOrWhiteSpace(episode.PreferredTitle?.Value) ? null : episode.PreferredTitle?.Value,
+            type = episode.Type,
+            number = episode.EpisodeNumber,
+            seasonnumber = episode.SeasonNumber,
+            airdate = DateTimeToTable(episode.AirDateWithTime),
+            getname = _getName,
         };
 
     private LuaArray<LuaRef<T>> ArrayOf<T>(IEnumerable<LuaRef<T>> items) where T : Table
@@ -529,15 +539,20 @@ public class LuaContext : Lua
         return GetTable("_");
     }
 
+    private LuaFunction Bind(MethodInfo method) => RegisterFunction("_", this, method);
+
     /// <summary>
-    /// Checks cache for a table or creates a new one if one doesn't exist
+    /// Returns the cached handle for a (<typeparamref name="TKey"/>, <paramref name="id"/>) entity, or
+    /// builds and caches a new one. The table is cached <em>before</em> <paramref name="build"/> runs so
+    /// recursive references (e.g. Anime → relations → Anime) resolve to the same table.
     /// </summary>
-    /// <returns>True if value was obtained from cache</returns>
-    private bool GetCachedOrNewTable((Type, int) key, out LuaTable value)
+    private LuaRef<TTable> Cached<TKey, TTable>(int id, Func<LuaTable, LuaRef<TTable>> build) where TTable : Table
     {
-        if (_tableCache.TryGetValue(key, out value!)) return true;
-        value = GetNewTable();
-        _tableCache[key] = value;
-        return false;
+        var key = (typeof(TKey), id);
+        if (_tableCache.TryGetValue(key, out var cached))
+            return new LuaRef<TTable>(cached);
+        var table = GetNewTable();
+        _tableCache[key] = table;
+        return build(table);
     }
 }

--- a/LuaRenamer/LuaContext.cs
+++ b/LuaRenamer/LuaContext.cs
@@ -199,7 +199,7 @@ public class LuaContext : Lua
             .OrderBy(g => g.MainSeriesID != _primarySeries.AnidbAnimeID)
             .Select(g => GroupToTable(g, getName)).ToList();
 
-        new EnvTableBuilder(env)
+        _ = new EnvTableBuilder(env)
         {
             logdebug = RegisterFunction("_", this, LogDebugMethod),
             log = RegisterFunction("_", this, LogMethod),
@@ -221,9 +221,9 @@ public class LuaContext : Lua
             groups = ArrayOf(groups),
             group = groups.Count > 0 ? groups[0] : null,
             tmdb = TmdbToTable(getName),
-        }.Build();
+        };
 
-        new EnumsTableBuilder(env)
+        _ = new EnumsTableBuilder(env)
         {
             AnimeType = EnumToTable<AnimeType>(),
             TitleType = EnumToTable<TitleType>(),
@@ -232,7 +232,7 @@ public class LuaContext : Lua
             ImportFolderType = EnumToTable<DropFolderType>(),
             RelationType = EnumToTable<RelationType>(),
             SeasonName = EnumToTable<YearlySeason>(),
-        }.Build();
+        };
 
         return env;
     }
@@ -255,7 +255,7 @@ public class LuaContext : Lua
             name = string.IsNullOrWhiteSpace(group.PreferredTitle?.Value) ? null : group.PreferredTitle?.Value,
             mainanime = AnimeToTable(group.MainSeries.AnidbAnime, false, getName),
             animes = ArrayOf(group.AllSeries.Select(a => AnimeToTable(a.AnidbAnime, false, getName))),
-        }.Build();
+        };
 
     private LuaRef<AnimeTable> AnimeToTable(IAnidbAnime anime, bool ignoreRelations, LuaFunction getName)
     {
@@ -284,7 +284,7 @@ public class LuaContext : Lua
             tags = ArrayOf(anime.Tags.Select(t => t.Name)),
             customtags = ArrayOf(series?.Tags.Select(t => t.Name) ?? []),
             seasons = ArrayOf(anime.YearlySeasons.Select(SeasonToTable)),
-        }.Build();
+        };
     }
 
     private LuaRef<SeasonTable> SeasonToTable((int Year, YearlySeason Season) season) =>
@@ -292,14 +292,14 @@ public class LuaContext : Lua
         {
             year = season.Year,
             season = season.Season,
-        }.Build();
+        };
 
     private LuaRef<RelationTable> RelationToTable(IRelatedMetadata<ISeries, ISeries> relation, LuaFunction getName) =>
         new RelationTableBuilder(GetNewTable())
         {
             anime = AnimeToTable((relation.Related as IAnidbAnime)!, true, getName),
             type = relation.RelationType,
-        }.Build();
+        };
 
     private LuaRef<AniDbTable>? AniDbFileToTable(IReleaseInfo? aniDb)
     {
@@ -317,19 +317,21 @@ public class LuaContext : Lua
             {
                 sublanguages = ArrayOf(aniDb.MediaInfo?.SubtitleLanguages ?? []),
                 dublanguages = ArrayOf(aniDb.MediaInfo?.AudioLanguages ?? []),
-            }.Build(),
+            },
             description = aniDb.Comment,
-        }.Build();
+        };
     }
 
-    private LuaRef<ReleaseGroupTable>? ReleaseGroupToTable(IReleaseGroup? releaseGroup) =>
-        releaseGroup?.ID is null || releaseGroup.Name == "raw/unknown"
-            ? null
-            : new ReleaseGroupTableBuilder(GetNewTable())
-            {
-                name = releaseGroup.Name,
-                shortname = releaseGroup.ShortName,
-            }.Build();
+    private LuaRef<ReleaseGroupTable>? ReleaseGroupToTable(IReleaseGroup? releaseGroup)
+    {
+        if (releaseGroup?.ID is null || releaseGroup.Name == "raw/unknown")
+            return null;
+        return new ReleaseGroupTableBuilder(GetNewTable())
+        {
+            name = releaseGroup.Name,
+            shortname = releaseGroup.ShortName,
+        };
+    }
 
     private LuaRef<EpisodeTable> EpisodeToTable(IAnidbEpisode episode, LuaFunction getName)
     {
@@ -346,7 +348,7 @@ public class LuaContext : Lua
             titles = ArrayOf(episode.Titles.OrderBy(t => t.Value).Select(TitleToTable)),
             getname = getName,
             prefix = Utils.EpPrefix[episode.Type],
-        }.Build();
+        };
     }
 
     private LuaRef<TitleTable> TitleToTable(ITitle title) =>
@@ -356,7 +358,7 @@ public class LuaContext : Lua
             language = title.Language,
             languagecode = title.LanguageCode,
             type = title.Type,
-        }.Build();
+        };
 
     private LuaRef<FileTable> FileToTable(IVideoFile file) =>
         new FileTableBuilder(GetNewTable())
@@ -372,11 +374,11 @@ public class LuaContext : Lua
                 md5 = file.Video.Hashes.FirstOrDefault(h => h.Type is "MD5")?.Value,
                 ed2k = file.Video.ED2K,
                 sha1 = file.Video.Hashes.FirstOrDefault(h => h.Type is "SHA1")?.Value,
-            }.Build(),
+            },
             anidb = AniDbFileToTable(file.Video.ReleaseInfo),
             media = MediaInfoToTable(file.Video.MediaInfo),
             importfolder = ImportFolderToTable(file.ManagedFolder),
-        }.Build();
+        };
 
     private LuaRef<ImportFolderTable> ImportFolderToTable(IManagedFolder folder)
     {
@@ -388,14 +390,17 @@ public class LuaContext : Lua
             name = folder.Name,
             location = folder.Path,
             type = folder.DropFolderType,
-        }.Build();
+        };
     }
 
-    private LuaRef<MediaTable>? MediaInfoToTable(IMediaInfo? mediaInfo) => mediaInfo is null ? null :
-        new MediaTableBuilder(GetNewTable())
+    private LuaRef<MediaTable>? MediaInfoToTable(IMediaInfo? mediaInfo)
+    {
+        if (mediaInfo is null)
+            return null;
+        return new MediaTableBuilder(GetNewTable())
         {
             video = mediaInfo.VideoStream is { } video
-                ? new VideoTableBuilder(GetNewTable())
+                ? (LuaRef<VideoTable>)new VideoTableBuilder(GetNewTable())
                 {
                     height = video.Height,
                     width = video.Width,
@@ -404,13 +409,13 @@ public class LuaContext : Lua
                     bitrate = video.BitRate,
                     bitdepth = video.BitDepth,
                     framerate = (double)video.FrameRate,
-                }.Build()
+                }
                 : null,
             chaptered = mediaInfo.Chapters.Any(),
             duration = (long)mediaInfo.Duration.TotalSeconds,
             bitrate = mediaInfo.BitRate,
             sublanguages = ArrayOf(mediaInfo.TextStreams.Select(s => s.Language.ToString())),
-            audio = ArrayOf(mediaInfo.AudioStreams.Select(a => new AudioTableBuilder(GetNewTable())
+            audio = ArrayOf(mediaInfo.AudioStreams.Select(a => (LuaRef<AudioTable>)new AudioTableBuilder(GetNewTable())
             {
                 compressionmode = a.CompressionMode,
                 channels = !string.IsNullOrWhiteSpace(a.ChannelLayout) && a.ChannelLayout.Contains("LFE") ? a.Channels - 1 + 0.1 : a.Channels,
@@ -418,11 +423,15 @@ public class LuaContext : Lua
                 codec = a.Codec.Simplified,
                 language = a.Language.ToString(),
                 title = a.Title,
-            }.Build())),
-        }.Build();
+            })),
+        };
+    }
 
-    private LuaRef<DateTimeTable>? DateTimeToTable(DateTime? dateTime) => dateTime is not { } dt ? null :
-        new DateTimeTableBuilder(GetNewTable())
+    private LuaRef<DateTimeTable>? DateTimeToTable(DateTime? dateTime)
+    {
+        if (dateTime is not { } dt)
+            return null;
+        return new DateTimeTableBuilder(GetNewTable())
         {
             year = dt.Year,
             month = dt.Month,
@@ -433,12 +442,13 @@ public class LuaContext : Lua
             min = dt.Minute,
             sec = dt.Second,
             isdst = dt.IsDaylightSavingTime(),
-        }.Build();
+        };
+    }
 
     private LuaRef<TmdbTable> TmdbToTable(LuaFunction getName) =>
         new TmdbTableBuilder(GetNewTable())
         {
-            movies = ArrayOf(_args.Series[0].TmdbMovies.Select(m => new TmdbMovieTableBuilder(GetNewTable())
+            movies = ArrayOf(_args.Series[0].TmdbMovies.Select(m => (LuaRef<TmdbMovieTable>)new TmdbMovieTableBuilder(GetNewTable())
             {
                 id = m.ID,
                 titles = ArrayOf(m.Titles.Select(TitleToTable)),
@@ -449,8 +459,8 @@ public class LuaContext : Lua
                 studios = ArrayOf(m.Studios.Select(s => s.Name)),
                 airdate = DateTimeToTable(m.ReleaseDate),
                 getname = getName,
-            }.Build())),
-            shows = ArrayOf(_args.Series[0].TmdbShows.Select(s => new TmdbShowTableBuilder(GetNewTable())
+            })),
+            shows = ArrayOf(_args.Series[0].TmdbShows.Select(s => (LuaRef<TmdbShowTable>)new TmdbShowTableBuilder(GetNewTable())
             {
                 id = s.ID,
                 titles = ArrayOf(s.Titles.Select(TitleToTable)),
@@ -464,9 +474,9 @@ public class LuaContext : Lua
                 enddate = DateTimeToTable(s.EndDate?.ToDateTime()),
                 getname = getName,
                 seasons = ArrayOf(s.YearlySeasons.Select(SeasonToTable)),
-            }.Build())),
+            })),
             episodes = ArrayOf(_args.Episodes.Where(e => e.SeriesID == _primarySeries.ID)
-                .SelectMany(e => e.TmdbEpisodes.Select(e2 => new TmdbEpisodeTableBuilder(GetNewTable())
+                .SelectMany(e => e.TmdbEpisodes.Select(e2 => (LuaRef<TmdbEpisodeTable>)new TmdbEpisodeTableBuilder(GetNewTable())
                 {
                     showid = e2.SeriesID,
                     id = e2.ID,
@@ -478,8 +488,8 @@ public class LuaContext : Lua
                     seasonnumber = e2.SeasonNumber,
                     airdate = DateTimeToTable(e2.AirDateWithTime),
                     getname = getName,
-                }.Build()))),
-        }.Build();
+                }))),
+        };
 
     private LuaArray<LuaRef<T>> ArrayOf<T>(IEnumerable<LuaRef<T>> items) where T : Table
     {

--- a/LuaRenamer/LuaContext.cs
+++ b/LuaRenamer/LuaContext.cs
@@ -181,13 +181,6 @@ public class LuaContext : Lua
     private LuaTable CreateLuaEnv(LuaFunction runSandboxed)
     {
         var env = (LuaTable)DoString(BaseEnv)[0];
-        new EnvTableBuilder(env)
-            .logdebug(RegisterFunction("_", this, LogDebugMethod))
-            .log(RegisterFunction("_", this, LogMethod))
-            .logwarn(RegisterFunction("_", this, LogWarnMethod))
-            .logerror(RegisterFunction("_", this, LogErrorMethod))
-            .episode_numbers(RegisterFunction("_", this, EpNumsMethod))
-            .Build();
         runSandboxed.Call(_luaLinqText, env);
         runSandboxed.Call(_luaUtilsText, env);
         var getName = (LuaFunction)runSandboxed.Call(GetNameFunction, env)[1];
@@ -207,32 +200,39 @@ public class LuaContext : Lua
             .Select(g => GroupToTable(g, getName)).ToList();
 
         new EnvTableBuilder(env)
-            .replace_illegal_chars(_args.Configuration.ReplaceIllegalCharacters)
-            .remove_illegal_chars(_args.Configuration.RemoveIllegalCharacters)
-            .use_existing_anime_location(_args.Configuration.UseExistingAnimeLocation)
-            .skip_rename(false)
-            .skip_move(false)
-            .illegal_chars_map(ReplaceMapToTable())
-            .animes(ArrayOf(animes))
-            .anime(animes[0])
-            .file(FileToTable(_args.File))
-            .episodes(ArrayOf(episodes))
-            .episode(episodes[0])
-            .importfolders(ArrayOf(_args.AvailableFolders.Select(ImportFolderToTable)))
-            .groups(ArrayOf(groups))
-            .group(groups.Count > 0 ? groups[0] : null)
-            .tmdb(TmdbToTable(getName))
-            .Build();
+        {
+            logdebug = RegisterFunction("_", this, LogDebugMethod),
+            log = RegisterFunction("_", this, LogMethod),
+            logwarn = RegisterFunction("_", this, LogWarnMethod),
+            logerror = RegisterFunction("_", this, LogErrorMethod),
+            episode_numbers = RegisterFunction("_", this, EpNumsMethod),
+            replace_illegal_chars = _args.Configuration.ReplaceIllegalCharacters,
+            remove_illegal_chars = _args.Configuration.RemoveIllegalCharacters,
+            use_existing_anime_location = _args.Configuration.UseExistingAnimeLocation,
+            skip_rename = false,
+            skip_move = false,
+            illegal_chars_map = ReplaceMapToTable(),
+            animes = ArrayOf(animes),
+            anime = animes[0],
+            file = FileToTable(_args.File),
+            episodes = ArrayOf(episodes),
+            episode = episodes[0],
+            importfolders = ArrayOf(_args.AvailableFolders.Select(ImportFolderToTable)),
+            groups = ArrayOf(groups),
+            group = groups.Count > 0 ? groups[0] : null,
+            tmdb = TmdbToTable(getName),
+        }.Build();
 
         new EnumsTableBuilder(env)
-            .AnimeType(EnumToTable<AnimeType>())
-            .TitleType(EnumToTable<TitleType>())
-            .Language(EnumToTable<TitleLanguage>())
-            .EpisodeType(EnumToTable<EpisodeType>())
-            .ImportFolderType(EnumToTable<DropFolderType>())
-            .RelationType(EnumToTable<RelationType>())
-            .SeasonName(EnumToTable<YearlySeason>())
-            .Build();
+        {
+            AnimeType = EnumToTable<AnimeType>(),
+            TitleType = EnumToTable<TitleType>(),
+            Language = EnumToTable<TitleLanguage>(),
+            EpisodeType = EnumToTable<EpisodeType>(),
+            ImportFolderType = EnumToTable<DropFolderType>(),
+            RelationType = EnumToTable<RelationType>(),
+            SeasonName = EnumToTable<YearlySeason>(),
+        }.Build();
 
         return env;
     }
@@ -251,10 +251,11 @@ public class LuaContext : Lua
 
     private LuaRef<GroupTable> GroupToTable(IShokoGroup group, LuaFunction getName) =>
         new GroupTableBuilder(GetNewTable())
-            .name(string.IsNullOrWhiteSpace(group.PreferredTitle?.Value) ? null : group.PreferredTitle?.Value)
-            .mainanime(AnimeToTable(group.MainSeries.AnidbAnime, false, getName))
-            .animes(ArrayOf(group.AllSeries.Select(a => AnimeToTable(a.AnidbAnime, false, getName))))
-            .Build();
+        {
+            name = string.IsNullOrWhiteSpace(group.PreferredTitle?.Value) ? null : group.PreferredTitle?.Value,
+            mainanime = AnimeToTable(group.MainSeries.AnidbAnime, false, getName),
+            animes = ArrayOf(group.AllSeries.Select(a => AnimeToTable(a.AnidbAnime, false, getName))),
+        }.Build();
 
     private LuaRef<AnimeTable> AnimeToTable(IAnidbAnime anime, bool ignoreRelations, LuaFunction getName)
     {
@@ -263,203 +264,222 @@ public class LuaContext : Lua
             return new LuaRef<AnimeTable>(animeTable);
         var series = anime.ShokoSeries.FirstOrDefault();
         return new AnimeTableBuilder(animeTable)
-            .airdate(DateTimeToTable(anime.AirDate?.ToDateTime()))
-            .enddate(DateTimeToTable(anime.EndDate?.ToDateTime()))
-            .rating(anime.Rating)
-            .restricted(anime.Restricted)
-            .type(anime.Type)
-            .preferredname(string.IsNullOrWhiteSpace(series?.Title) ? anime.Title : series.Title)
-            .defaultname(string.IsNullOrWhiteSpace(series?.DefaultTitle.Value) ? anime.DefaultTitle.Value : series.DefaultTitle.Value)
-            .id(anime.ID)
-            .titles(ArrayOf(anime.Titles.OrderBy(t => t.Value).Select(TitleToTable)))
-            .getname(getName)
-            .studios(ArrayOf(anime.Studios.Select(st => st.Name)))
-            .episodecounts(MapOf(Enum.GetValues<EpisodeType>().Select(ep => (ep, (long)anime.EpisodeCounts[ep]))))
-            .relations(ArrayOf(ignoreRelations
+        {
+            airdate = DateTimeToTable(anime.AirDate?.ToDateTime()),
+            enddate = DateTimeToTable(anime.EndDate?.ToDateTime()),
+            rating = anime.Rating,
+            restricted = anime.Restricted,
+            type = anime.Type,
+            preferredname = string.IsNullOrWhiteSpace(series?.Title) ? anime.Title : series.Title,
+            defaultname = string.IsNullOrWhiteSpace(series?.DefaultTitle.Value) ? anime.DefaultTitle.Value : series.DefaultTitle.Value,
+            id = anime.ID,
+            titles = ArrayOf(anime.Titles.OrderBy(t => t.Value).Select(TitleToTable)),
+            getname = getName,
+            studios = ArrayOf(anime.Studios.Select(st => st.Name)),
+            episodecounts = MapOf(Enum.GetValues<EpisodeType>().Select(ep => (ep, (long)anime.EpisodeCounts[ep]))),
+            relations = ArrayOf(ignoreRelations
                 ? Enumerable.Empty<LuaRef<RelationTable>>()
                 : anime.RelatedSeries.Where(r => r.Related is not null && r.Related.ID != anime.ID)
-                    .Select(r => RelationToTable(r, getName))))
-            .tags(ArrayOf(anime.Tags.Select(t => t.Name)))
-            .customtags(ArrayOf(series?.Tags.Select(t => t.Name) ?? []))
-            .seasons(ArrayOf(anime.YearlySeasons.Select(SeasonToTable)))
-            .Build();
+                    .Select(r => RelationToTable(r, getName))),
+            tags = ArrayOf(anime.Tags.Select(t => t.Name)),
+            customtags = ArrayOf(series?.Tags.Select(t => t.Name) ?? []),
+            seasons = ArrayOf(anime.YearlySeasons.Select(SeasonToTable)),
+        }.Build();
     }
 
     private LuaRef<SeasonTable> SeasonToTable((int Year, YearlySeason Season) season) =>
         new SeasonTableBuilder(GetNewTable())
-            .year(season.Year)
-            .season(season.Season)
-            .Build();
+        {
+            year = season.Year,
+            season = season.Season,
+        }.Build();
 
     private LuaRef<RelationTable> RelationToTable(IRelatedMetadata<ISeries, ISeries> relation, LuaFunction getName) =>
         new RelationTableBuilder(GetNewTable())
-            .anime(AnimeToTable((relation.Related as IAnidbAnime)!, true, getName))
-            .type(relation.RelationType)
-            .Build();
+        {
+            anime = AnimeToTable((relation.Related as IAnidbAnime)!, true, getName),
+            type = relation.RelationType,
+        }.Build();
 
     private LuaRef<AniDbTable>? AniDbFileToTable(IReleaseInfo? aniDb)
     {
         if (aniDb is not { ReleaseURI: var releaseUri } || !(releaseUri?.StartsWith("https://anidb.net/file/") ?? false))
             return null;
         return new AniDbTableBuilder(GetNewTable())
-            .id(int.Parse(aniDb.ReleaseURI![23..]))
-            .censored(aniDb.IsCensored)
-            .source(Enum.GetName(aniDb.Source)!)
-            .version(aniDb.Version)
-            .releasedate(DateTimeToTable(aniDb.ReleasedAt?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified)))
-            .releasegroup(ReleaseGroupToTable(aniDb.Group))
-            .media(new AniDbMediaTableBuilder(GetNewTable())
-                .sublanguages(ArrayOf(aniDb.MediaInfo?.SubtitleLanguages ?? []))
-                .dublanguages(ArrayOf(aniDb.MediaInfo?.AudioLanguages ?? []))
-                .Build())
-            .description(aniDb.Comment)
-            .Build();
+        {
+            id = int.Parse(aniDb.ReleaseURI![23..]),
+            censored = aniDb.IsCensored,
+            source = Enum.GetName(aniDb.Source)!,
+            version = aniDb.Version,
+            releasedate = DateTimeToTable(aniDb.ReleasedAt?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified)),
+            releasegroup = ReleaseGroupToTable(aniDb.Group),
+            media = new AniDbMediaTableBuilder(GetNewTable())
+            {
+                sublanguages = ArrayOf(aniDb.MediaInfo?.SubtitleLanguages ?? []),
+                dublanguages = ArrayOf(aniDb.MediaInfo?.AudioLanguages ?? []),
+            }.Build(),
+            description = aniDb.Comment,
+        }.Build();
     }
 
     private LuaRef<ReleaseGroupTable>? ReleaseGroupToTable(IReleaseGroup? releaseGroup) =>
         releaseGroup?.ID is null || releaseGroup.Name == "raw/unknown"
             ? null
             : new ReleaseGroupTableBuilder(GetNewTable())
-                .name(releaseGroup.Name)
-                .shortname(releaseGroup.ShortName)
-                .Build();
+            {
+                name = releaseGroup.Name,
+                shortname = releaseGroup.ShortName,
+            }.Build();
 
     private LuaRef<EpisodeTable> EpisodeToTable(IAnidbEpisode episode, LuaFunction getName)
     {
         if (GetCachedOrNewTable((typeof(IAnidbEpisode), episode.ID), out var epTable))
             return new LuaRef<EpisodeTable>(epTable);
         return new EpisodeTableBuilder(epTable)
-            .duration((long)episode.Runtime.TotalSeconds)
-            .number(episode.EpisodeNumber)
-            .type(episode.Type)
-            .airdate(DateTimeToTable(episode.AirDateWithTime))
-            .animeid(episode.SeriesID)
-            .id(episode.ID)
-            .titles(ArrayOf(episode.Titles.OrderBy(t => t.Value).Select(TitleToTable)))
-            .getname(getName)
-            .prefix(Utils.EpPrefix[episode.Type])
-            .Build();
+        {
+            duration = (long)episode.Runtime.TotalSeconds,
+            number = episode.EpisodeNumber,
+            type = episode.Type,
+            airdate = DateTimeToTable(episode.AirDateWithTime),
+            animeid = episode.SeriesID,
+            id = episode.ID,
+            titles = ArrayOf(episode.Titles.OrderBy(t => t.Value).Select(TitleToTable)),
+            getname = getName,
+            prefix = Utils.EpPrefix[episode.Type],
+        }.Build();
     }
 
     private LuaRef<TitleTable> TitleToTable(ITitle title) =>
         new TitleTableBuilder(GetNewTable())
-            .name(title.Value)
-            .language(title.Language)
-            .languagecode(title.LanguageCode)
-            .type(title.Type)
-            .Build();
+        {
+            name = title.Value,
+            language = title.Language,
+            languagecode = title.LanguageCode,
+            type = title.Type,
+        }.Build();
 
     private LuaRef<FileTable> FileToTable(IVideoFile file) =>
         new FileTableBuilder(GetNewTable())
-            .name(Path.GetFileNameWithoutExtension(file.FileName))
-            .extension(Path.GetExtension(file.FileName))
-            .path(file.Path)
-            .size(file.Size)
-            .earliestname(Path.GetFileNameWithoutExtension(file.Video.EarliestKnownName))
-            .hashes(new HashesTableBuilder(GetNewTable())
-                .crc(file.Video.Hashes.FirstOrDefault(h => h.Type is "CRC32")?.Value)
-                .md5(file.Video.Hashes.FirstOrDefault(h => h.Type is "MD5")?.Value)
-                .ed2k(file.Video.ED2K)
-                .sha1(file.Video.Hashes.FirstOrDefault(h => h.Type is "SHA1")?.Value)
-                .Build())
-            .anidb(AniDbFileToTable(file.Video.ReleaseInfo))
-            .media(MediaInfoToTable(file.Video.MediaInfo))
-            .importfolder(ImportFolderToTable(file.ManagedFolder))
-            .Build();
+        {
+            name = Path.GetFileNameWithoutExtension(file.FileName),
+            extension = Path.GetExtension(file.FileName),
+            path = file.Path,
+            size = file.Size,
+            earliestname = Path.GetFileNameWithoutExtension(file.Video.EarliestKnownName),
+            hashes = new HashesTableBuilder(GetNewTable())
+            {
+                crc = file.Video.Hashes.FirstOrDefault(h => h.Type is "CRC32")?.Value,
+                md5 = file.Video.Hashes.FirstOrDefault(h => h.Type is "MD5")?.Value,
+                ed2k = file.Video.ED2K,
+                sha1 = file.Video.Hashes.FirstOrDefault(h => h.Type is "SHA1")?.Value,
+            }.Build(),
+            anidb = AniDbFileToTable(file.Video.ReleaseInfo),
+            media = MediaInfoToTable(file.Video.MediaInfo),
+            importfolder = ImportFolderToTable(file.ManagedFolder),
+        }.Build();
 
     private LuaRef<ImportFolderTable> ImportFolderToTable(IManagedFolder folder)
     {
         if (GetCachedOrNewTable((typeof(IManagedFolder), folder.ID), out var importTable))
             return new LuaRef<ImportFolderTable>(importTable);
         return new ImportFolderTableBuilder(importTable)
-            .id(folder.ID)
-            .name(folder.Name)
-            .location(folder.Path)
-            .type(folder.DropFolderType)
-            .Build();
+        {
+            id = folder.ID,
+            name = folder.Name,
+            location = folder.Path,
+            type = folder.DropFolderType,
+        }.Build();
     }
 
     private LuaRef<MediaTable>? MediaInfoToTable(IMediaInfo? mediaInfo) => mediaInfo is null ? null :
         new MediaTableBuilder(GetNewTable())
-            .video(mediaInfo.VideoStream is { } video
+        {
+            video = mediaInfo.VideoStream is { } video
                 ? new VideoTableBuilder(GetNewTable())
-                    .height(video.Height)
-                    .width(video.Width)
-                    .codec(video.Codec.Simplified)
-                    .res(video.Resolution)
-                    .bitrate(video.BitRate)
-                    .bitdepth(video.BitDepth)
-                    .framerate((double)video.FrameRate)
-                    .Build()
-                : null)
-            .chaptered(mediaInfo.Chapters.Any())
-            .duration((long)mediaInfo.Duration.TotalSeconds)
-            .bitrate(mediaInfo.BitRate)
-            .sublanguages(ArrayOf(mediaInfo.TextStreams.Select(s => s.Language.ToString())))
-            .audio(ArrayOf(mediaInfo.AudioStreams.Select(a => new AudioTableBuilder(GetNewTable())
-                .compressionmode(a.CompressionMode)
-                .channels(!string.IsNullOrWhiteSpace(a.ChannelLayout) && a.ChannelLayout.Contains("LFE") ? a.Channels - 1 + 0.1 : a.Channels)
-                .samplingrate(a.SamplingRate)
-                .codec(a.Codec.Simplified)
-                .language(a.Language.ToString())
-                .title(a.Title)
-                .Build())))
-            .Build();
+                {
+                    height = video.Height,
+                    width = video.Width,
+                    codec = video.Codec.Simplified,
+                    res = video.Resolution,
+                    bitrate = video.BitRate,
+                    bitdepth = video.BitDepth,
+                    framerate = (double)video.FrameRate,
+                }.Build()
+                : null,
+            chaptered = mediaInfo.Chapters.Any(),
+            duration = (long)mediaInfo.Duration.TotalSeconds,
+            bitrate = mediaInfo.BitRate,
+            sublanguages = ArrayOf(mediaInfo.TextStreams.Select(s => s.Language.ToString())),
+            audio = ArrayOf(mediaInfo.AudioStreams.Select(a => new AudioTableBuilder(GetNewTable())
+            {
+                compressionmode = a.CompressionMode,
+                channels = !string.IsNullOrWhiteSpace(a.ChannelLayout) && a.ChannelLayout.Contains("LFE") ? a.Channels - 1 + 0.1 : a.Channels,
+                samplingrate = a.SamplingRate,
+                codec = a.Codec.Simplified,
+                language = a.Language.ToString(),
+                title = a.Title,
+            }.Build())),
+        }.Build();
 
     private LuaRef<DateTimeTable>? DateTimeToTable(DateTime? dateTime) => dateTime is not { } dt ? null :
         new DateTimeTableBuilder(GetNewTable())
-            .year(dt.Year)
-            .month(dt.Month)
-            .day(dt.Day)
-            .yday(dt.DayOfYear)
-            .wday((long)dt.DayOfWeek + 1)
-            .hour(dt.Hour)
-            .min(dt.Minute)
-            .sec(dt.Second)
-            .isdst(dt.IsDaylightSavingTime())
-            .Build();
+        {
+            year = dt.Year,
+            month = dt.Month,
+            day = dt.Day,
+            yday = dt.DayOfYear,
+            wday = (long)dt.DayOfWeek + 1,
+            hour = dt.Hour,
+            min = dt.Minute,
+            sec = dt.Second,
+            isdst = dt.IsDaylightSavingTime(),
+        }.Build();
 
     private LuaRef<TmdbTable> TmdbToTable(LuaFunction getName) =>
         new TmdbTableBuilder(GetNewTable())
-            .movies(ArrayOf(_args.Series[0].TmdbMovies.Select(m => new TmdbMovieTableBuilder(GetNewTable())
-                .id(m.ID)
-                .titles(ArrayOf(m.Titles.Select(TitleToTable)))
-                .defaultname(string.IsNullOrWhiteSpace(m.DefaultTitle?.Value) ? null : m.DefaultTitle?.Value)
-                .preferredname(string.IsNullOrWhiteSpace(m.PreferredTitle?.Value) ? null : m.PreferredTitle?.Value)
-                .rating(m.Rating)
-                .restricted(m.Restricted)
-                .studios(ArrayOf(m.Studios.Select(s => s.Name)))
-                .airdate(DateTimeToTable(m.ReleaseDate))
-                .getname(getName)
-                .Build())))
-            .shows(ArrayOf(_args.Series[0].TmdbShows.Select(s => new TmdbShowTableBuilder(GetNewTable())
-                .id(s.ID)
-                .titles(ArrayOf(s.Titles.Select(TitleToTable)))
-                .defaultname(string.IsNullOrWhiteSpace(s.DefaultTitle?.Value) ? null : s.DefaultTitle?.Value)
-                .preferredname(string.IsNullOrWhiteSpace(s.PreferredTitle?.Value) ? null : s.PreferredTitle?.Value)
-                .rating(s.Rating)
-                .restricted(s.Restricted)
-                .studios(ArrayOf(s.Studios.Select(st => st.Name)))
-                .episodecount(s.EpisodeCounts.Episodes)
-                .airdate(DateTimeToTable(s.AirDate?.ToDateTime()))
-                .enddate(DateTimeToTable(s.EndDate?.ToDateTime()))
-                .getname(getName)
-                .seasons(ArrayOf(s.YearlySeasons.Select(SeasonToTable)))
-                .Build())))
-            .episodes(ArrayOf(_args.Episodes.Where(e => e.SeriesID == _primarySeries.ID)
+        {
+            movies = ArrayOf(_args.Series[0].TmdbMovies.Select(m => new TmdbMovieTableBuilder(GetNewTable())
+            {
+                id = m.ID,
+                titles = ArrayOf(m.Titles.Select(TitleToTable)),
+                defaultname = string.IsNullOrWhiteSpace(m.DefaultTitle?.Value) ? null : m.DefaultTitle?.Value,
+                preferredname = string.IsNullOrWhiteSpace(m.PreferredTitle?.Value) ? null : m.PreferredTitle?.Value,
+                rating = m.Rating,
+                restricted = m.Restricted,
+                studios = ArrayOf(m.Studios.Select(s => s.Name)),
+                airdate = DateTimeToTable(m.ReleaseDate),
+                getname = getName,
+            }.Build())),
+            shows = ArrayOf(_args.Series[0].TmdbShows.Select(s => new TmdbShowTableBuilder(GetNewTable())
+            {
+                id = s.ID,
+                titles = ArrayOf(s.Titles.Select(TitleToTable)),
+                defaultname = string.IsNullOrWhiteSpace(s.DefaultTitle?.Value) ? null : s.DefaultTitle?.Value,
+                preferredname = string.IsNullOrWhiteSpace(s.PreferredTitle?.Value) ? null : s.PreferredTitle?.Value,
+                rating = s.Rating,
+                restricted = s.Restricted,
+                studios = ArrayOf(s.Studios.Select(st => st.Name)),
+                episodecount = s.EpisodeCounts.Episodes,
+                airdate = DateTimeToTable(s.AirDate?.ToDateTime()),
+                enddate = DateTimeToTable(s.EndDate?.ToDateTime()),
+                getname = getName,
+                seasons = ArrayOf(s.YearlySeasons.Select(SeasonToTable)),
+            }.Build())),
+            episodes = ArrayOf(_args.Episodes.Where(e => e.SeriesID == _primarySeries.ID)
                 .SelectMany(e => e.TmdbEpisodes.Select(e2 => new TmdbEpisodeTableBuilder(GetNewTable())
-                    .showid(e2.SeriesID)
-                    .id(e2.ID)
-                    .titles(ArrayOf(e2.Titles.Select(TitleToTable)))
-                    .defaultname(string.IsNullOrWhiteSpace(e2.DefaultTitle?.Value) ? null : e2.DefaultTitle?.Value)
-                    .preferredname(string.IsNullOrWhiteSpace(e2.PreferredTitle?.Value) ? null : e2.PreferredTitle?.Value)
-                    .type(e2.Type)
-                    .number(e2.EpisodeNumber)
-                    .seasonnumber(e2.SeasonNumber)
-                    .airdate(DateTimeToTable(e2.AirDateWithTime))
-                    .getname(getName)
-                    .Build()))))
-            .Build();
+                {
+                    showid = e2.SeriesID,
+                    id = e2.ID,
+                    titles = ArrayOf(e2.Titles.Select(TitleToTable)),
+                    defaultname = string.IsNullOrWhiteSpace(e2.DefaultTitle?.Value) ? null : e2.DefaultTitle?.Value,
+                    preferredname = string.IsNullOrWhiteSpace(e2.PreferredTitle?.Value) ? null : e2.PreferredTitle?.Value,
+                    type = e2.Type,
+                    number = e2.EpisodeNumber,
+                    seasonnumber = e2.SeasonNumber,
+                    airdate = DateTimeToTable(e2.AirDateWithTime),
+                    getname = getName,
+                }.Build()))),
+        }.Build();
 
     private LuaArray<LuaRef<T>> ArrayOf<T>(IEnumerable<LuaRef<T>> items) where T : Table
     {


### PR DESCRIPTION
## Summary
Reworks the generated Lua table builders and their use in `LuaContext`:

- **Required-member completeness** — each builder field is a `required` init member, so omitting any non-`Output` field is a compile error (CS9035). `EnvTable` is populated in a single initializer after sandboxing.
- **No `Build()`** — builders write straight into the `LuaTable` in their `init` setters and expose an implicit conversion to their typed `LuaRef<T>` handle, so a populated builder *is* the handle.
- **LuaContext readability pass** — extracted `Video/Audio/Tmdb{Movie,Show,Episode}ToTable` helpers (removing inline-Select casts), made `getName` a build-scoped field instead of a threaded parameter, added a generic `Cached<TKey,TTable>` helper, and a `Bind()` helper for log registrations.

Type safety, the navigation DSL, and the `LuaDefsGenerator` docs (`defs.lua`/`enums.lua`/`env.lua`) are unchanged.

## Test plan
- [x] `dotnet build LuaRenamer.slnx` — 0 warnings, 0 errors
- [x] `dotnet test LuaRenamer.slnx` — 71/71 (60 integration + 11 generator)
- [x] Omitting a builder field yields CS9035