### PR TITLE
Introduce LuaFunctionRef<TDelegate> for unified function bindings (Unit 1)

### DIFF
--- a/LuaBuilderGenerator/NamesGenerator.cs
+++ b/LuaBuilderGenerator/NamesGenerator.cs
@@ -19,9 +19,6 @@ public class NamesGenerator : IIncrementalGenerator
     private const string Ns = "LuaRenamer.LuaEnv";
     private const string Bt = "global::LuaRenamer.LuaEnv.BaseTypes";
 
-    private static readonly SymbolDisplayFormat FqNullable = SymbolDisplayFormat.FullyQualifiedFormat
-        .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
-
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var source = context.CompilationProvider.Select(static (compilation, _) => Build(compilation));
@@ -76,6 +73,29 @@ public class NamesGenerator : IIncrementalGenerator
 
             switch (member)
             {
+                // Function binding property: LuaFunctionRef<TDelegate> with [LuaField].
+                // Must be matched before the generic [LuaField] data case since these props also carry [LuaField].
+                case IPropertySymbol prop when GetAttr(prop, "LuaFieldAttribute") is not null
+                    && prop.Type is INamedTypeSymbol { Name: "LuaFunctionRef", TypeArguments.Length: 1 } funcRef
+                    && funcRef.TypeArguments[0] is INamedTypeSymbol del:
+                {
+                    var ta = del.TypeArguments;
+                    var n = del.Name == "Func" ? ta.Length - 1 : ta.Length;
+                    var pars = new List<string>();
+                    var args = new List<string>();
+                    for (var i = 0; i < n; i++)
+                    {
+                        var isNull = ta[i] is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
+                            || ta[i].NullableAnnotation == NullableAnnotation.Annotated;
+                        pars.Add(isNull ? $"string? p{i} = null" : $"string p{i}");
+                        args.Add($"p{i}");
+                    }
+                    var body = isRoot
+                        ? $"GetFunc([{string.Join(", ", args)}])"
+                        : $"GetFunc([{string.Join(", ", args)}], ':')";
+                    sb.Append($"    public {staticKw}string {prop.Name}({string.Join(", ", pars)}) => {body};\n");
+                    break;
+                }
                 // Bound data field: [LuaField] on a property.
                 case IPropertySymbol prop when GetAttr(prop, "LuaFieldAttribute") is not null:
                 {
@@ -88,32 +108,6 @@ public class NamesGenerator : IIncrementalGenerator
                 case IPropertySymbol prop when GetAttr(prop, "LuaTypeAttribute") is { } typeAttr && GetBool(typeAttr, "Output"):
                     sb.Append($"    public {staticKw}string {prop.Name} => Get();\n");
                     break;
-                // Function binding property: [LuaType(function)] on a Func/Action property.
-                case IPropertySymbol prop when GetAttr(prop, "LuaTypeAttribute") is not null
-                    && prop.Type is INamedTypeSymbol { Name: "Func" or "Action" }:
-                {
-                    var paramAttrs = prop.GetAttributes()
-                        .Where(a => a.AttributeClass?.Name == "LuaParameterAttribute")
-                        .Select(a => a.ConstructorArguments.Length > 0 ? a.ConstructorArguments[0].Value as string ?? "" : "")
-                        .ToList();
-                    var paramList = string.Join(", ", paramAttrs.Select(n => $"string {n}"));
-                    var argArray = string.Join(", ", paramAttrs);
-                    var body = isRoot ? $"GetFunc([{argArray}])" : $"GetFunc([{argArray}], ':')";
-                    sb.Append($"    public {staticKw}string {prop.Name}({paramList}) => {body};\n");
-                    break;
-                }
-                // Function member: [LuaType(function)] on an ordinary method.
-                case IMethodSymbol { MethodKind: MethodKind.Ordinary } method when GetAttr(method, "LuaTypeAttribute") is not null:
-                {
-                    var paramList = string.Join(", ", method.Parameters.Select(FormatParam));
-                    var argArray = string.Join(", ", method.Parameters.Select(p => p.Name));
-                    // Root functions are called with () syntax; instance methods use : syntax in Lua.
-                    var body = isRoot
-                        ? $"GetFunc([{argArray}])"
-                        : $"GetFunc([{argArray}], ':')";
-                    sb.Append($"    public {staticKw}string {method.Name}({paramList}) => {body};\n");
-                    break;
-                }
             }
         }
 
@@ -164,19 +158,19 @@ public class NamesGenerator : IIncrementalGenerator
                 case "LuaMap":
                     sb.Append($"    public {staticKw}string {name} => Get();\n");
                     return;
+                case "LuaEnumRef" when named.TypeArguments.Length == 1:
+                {
+                    var enumType = named.TypeArguments[0];
+                    var fqEnum = enumType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    var pascalName = char.ToUpper(name[0]) + name.Substring(1); // camelCase → PascalCase
+                    sb.Append($"    public {staticKw}{Bt}.EnumTable<{fqEnum}> {pascalName} => new() {{ Fn = Get() }};\n");
+                    return;
+                }
             }
         }
 
         // Scalars (long, double, bool, string, string?, enum) — leaf string.
         sb.Append($"    public {staticKw}string {name} => Get();\n");
-    }
-
-    private static string FormatParam(IParameterSymbol p)
-    {
-        var typeStr = p.Type.ToDisplayString(FqNullable);
-        return p.HasExplicitDefaultValue
-            ? $"{typeStr} {p.Name} = {(p.ExplicitDefaultValue is null ? "null" : $"\"{p.ExplicitDefaultValue}\"")}"
-            : $"{typeStr} {p.Name}";
     }
 
     private static string TableToNames(string name) =>

--- a/LuaDefsGenerator/Generator.cs
+++ b/LuaDefsGenerator/Generator.cs
@@ -12,7 +12,7 @@ public class Generator
     private readonly string _outputPath;
 
     // Maps CLR enum type -> Lua name (e.g. typeof(AnimeType) -> "AnimeType").
-    // Built once from EnumsTable's EnumTable<T> properties.
+    // Built once from EnumsTable's LuaEnumRef<T> instance properties.
     private static readonly Dictionary<Type, string> EnumToLuaName = BuildEnumMap();
 
     public Generator(string outputPath) => _outputPath = Path.GetFullPath(outputPath);
@@ -27,12 +27,12 @@ public class Generator
     private static Dictionary<Type, string> BuildEnumMap()
     {
         var result = new Dictionary<Type, string>();
-        foreach (var prop in typeof(EnumsTable).GetProperties(BindingFlags.Public | BindingFlags.Static))
+        foreach (var prop in typeof(EnumsTable).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                     .Where(p => p.PropertyType.IsGenericType &&
+                                 p.PropertyType.GetGenericTypeDefinition() == typeof(LuaEnumRef<>)))
         {
-            if (!prop.PropertyType.IsGenericType) continue;
-            if (prop.PropertyType.GetGenericTypeDefinition() != typeof(EnumTable<>)) continue;
             var enumType = prop.PropertyType.GetGenericArguments()[0];
-            result[enumType] = prop.Name;
+            result[enumType] = char.ToUpper(prop.Name[0]) + prop.Name.Substring(1); // camelCase → PascalCase
         }
         return result;
     }
@@ -51,29 +51,34 @@ public class Generator
         foreach (var type in types)
         {
             var className = type.LuaTypeAttribute!.Type;
-            var functions = new List<(MemberInfo member, LuaTypeAttribute typeAttr)>();
+            var functions = new List<(PropertyInfo prop, LuaFieldAttribute fieldAttr)>();
             sb.Append($"---@class (exact) {className}\n");
 
             foreach (var member in type.Type.GetMembers(BindingFlags.Public | BindingFlags.Instance))
             {
                 if (member.GetCustomAttribute<LuaTypeAttribute>() is { } typeAttr)
                 {
-                    if (typeAttr.Type == LuaTypeNames.function)
-                        functions.Add((member, typeAttr));
-                    else
-                        sb.Append($"---@field {member.Name} {typeAttr.Type}{(typeAttr.Description is { } desc ? $" # {desc}" : string.Empty)}\n");
+                    sb.Append($"---@field {member.Name} {typeAttr.Type}{(typeAttr.Description is { } desc ? $" # {desc}" : string.Empty)}\n");
                 }
                 else if (member is PropertyInfo prop && prop.GetCustomAttribute<LuaFieldAttribute>() is { } fieldAttr)
                 {
-                    var luaType = InferLuaType(prop, ctx);
-                    sb.Append($"---@field {member.Name} {luaType}{(fieldAttr.Description is { } desc ? $" # {desc}" : string.Empty)}\n");
+                    if (prop.PropertyType.IsGenericType &&
+                        prop.PropertyType.GetGenericTypeDefinition() == typeof(LuaFunctionRef<>))
+                    {
+                        functions.Add((prop, fieldAttr));
+                    }
+                    else
+                    {
+                        var luaType = InferLuaType(prop, ctx);
+                        sb.Append($"---@field {member.Name} {luaType}{(fieldAttr.Description is { } desc ? $" # {desc}" : string.Empty)}\n");
+                    }
                 }
             }
 
             sb.Append($"local {className} = {{}}\n\n");
 
             foreach (var func in functions)
-                GenerateFunctionAnnotations(sb, func.member, func.typeAttr, $"{className}:{func.member.Name}");
+                GenerateFunctionAnnotations(sb, func.prop, func.fieldAttr, $"{className}:{func.prop.Name}", ctx);
         }
 
         sb.Length--;
@@ -97,6 +102,17 @@ public class Generator
         var isNullableRef = t.IsClass && (nullInfo.ReadState == NullabilityState.Nullable || nullInfo.WriteState == NullabilityState.Nullable);
 
         return InferLuaTypeForInner(t) + (isNullableRef ? "|nil" : "");
+    }
+
+    private static string InferLuaTypeForArg(Type t, NullabilityInfo? nullInfo)
+    {
+        // Nullable<T> value types (bool?, long?, enum?)
+        if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>))
+            return InferLuaTypeForInner(t.GetGenericArguments()[0]) + "|nil";
+        // Nullable reference types (string?)
+        var isNullRef = nullInfo != null &&
+                        (nullInfo.ReadState == NullabilityState.Nullable || nullInfo.WriteState == NullabilityState.Nullable);
+        return InferLuaTypeForInner(t) + (isNullRef ? "|nil" : "");
     }
 
     private static string InferLuaTypeForInner(Type t)
@@ -210,12 +226,15 @@ public class Generator
         var enumsType = typeof(EnumsTable);
         var sb = new StringBuilder();
         sb.Append("---@meta\n\n");
-        foreach (var prop in enumsType.GetProperties(BindingFlags.Public | BindingFlags.Static))
+        foreach (var prop in enumsType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                     .Where(p => p.PropertyType.IsGenericType &&
+                                 p.PropertyType.GetGenericTypeDefinition() == typeof(LuaEnumRef<>)))
         {
             var enumType = prop.PropertyType.GenericTypeArguments[0];
+            var propName = char.ToUpper(prop.Name[0]) + prop.Name.Substring(1); // camelCase → PascalCase
 
-            sb.Append($"---@enum {prop.Name}\n");
-            sb.Append($"{prop.Name} = {{\n");
+            sb.Append($"---@enum {propName}\n");
+            sb.Append($"{propName} = {{\n");
 
             if (enumType == typeof(TitleLanguage))
             {
@@ -257,19 +276,43 @@ public class Generator
         }
     }
 
-    private static void GenerateFunctionAnnotations(StringBuilder sb, MemberInfo member, LuaTypeAttribute typeAttr, string functionName)
+    private static void GenerateFunctionAnnotations(StringBuilder sb, PropertyInfo prop, LuaFieldAttribute fieldAttr, string functionName,
+        NullabilityInfoContext ctx)
     {
-        if (typeAttr.Description is { } description)
+        if (fieldAttr.Description is { } description)
             sb.Append($"---{description}\n");
 
-        var parameters = member.GetCustomAttributes<LuaParameterAttribute>().ToList();
-        foreach (var param in parameters)
-            sb.Append($"---@param {param.Name} {param.Type} {param.Description}\n");
+        var delegateType = prop.PropertyType.GetGenericArguments()[0]; // TDelegate from LuaFunctionRef<TDelegate>
+        var delegateArgs = delegateType.GetGenericArguments();
+        var isFunc = delegateType.GetGenericTypeDefinition().Name.StartsWith("Func");
+        var paramCount = isFunc ? delegateArgs.Length - 1 : delegateArgs.Length;
 
-        if (member.GetCustomAttribute<LuaReturnTypeAttribute>() is { } returnAttr)
-            sb.Append($"---@return {returnAttr.Type}\n");
+        // NullabilityInfo for the generic type args: prop -> LuaFunctionRef<T> -> T (the delegate) -> its args.
+        var nullInfo = ctx.Create(prop);
+        var funcNullArgs = nullInfo.GenericTypeArguments.Length > 0
+            ? nullInfo.GenericTypeArguments[0].GenericTypeArguments
+            : Array.Empty<NullabilityInfo>();
 
-        sb.Append($"function {functionName}({string.Join(", ", parameters.Select(p => p.Name))}) end\n\n");
+        for (var i = 0; i < paramCount; i++)
+        {
+            var argNullInfo = i < funcNullArgs.Length ? funcNullArgs[i] : null;
+            var luaType = InferLuaTypeForArg(delegateArgs[i], argNullInfo);
+            sb.Append($"---@param p{i} {luaType}\n");
+        }
+
+        if (isFunc)
+        {
+            var retIdx = delegateArgs.Length - 1;
+            var retNullInfo = retIdx < funcNullArgs.Length ? funcNullArgs[retIdx] : null;
+            var retType = InferLuaTypeForArg(delegateArgs[retIdx], retNullInfo);
+            sb.Append($"---@return {retType}\n");
+        }
+        else
+        {
+            sb.Append("---@return nil\n");
+        }
+
+        sb.Append($"function {functionName}({string.Join(", ", Enumerable.Range(0, paramCount).Select(i => $"p{i}"))}) end\n\n");
     }
 
     private void GenerateEnvFile()
@@ -283,25 +326,26 @@ public class Generator
         {
             if (member.GetCustomAttribute<LuaTypeAttribute>() is { } typeAttr)
             {
-                if (typeAttr.Type == LuaTypeNames.function)
-                {
-                    GenerateFunctionAnnotations(sb, member, typeAttr, member.Name);
-                }
-                else
-                {
-                    if (typeAttr.Description is { } description)
-                        sb.Append($"---{description}\n");
-                    sb.Append($"---@type {typeAttr.Type}\n");
-                    sb.Append($"{member.Name} = {typeAttr.DefaultValue}\n\n");
-                }
+                if (typeAttr.Description is { } description)
+                    sb.Append($"---{description}\n");
+                sb.Append($"---@type {typeAttr.Type}\n");
+                sb.Append($"{member.Name} = {typeAttr.DefaultValue}\n\n");
             }
             else if (member is PropertyInfo prop && prop.GetCustomAttribute<LuaFieldAttribute>() is { } fieldAttr)
             {
-                var luaType = InferLuaType(prop, ctx);
-                if (fieldAttr.Description is { } desc)
-                    sb.Append($"---{desc}\n");
-                sb.Append($"---@type {luaType}\n");
-                sb.Append($"{prop.Name} = {fieldAttr.DefaultValue}\n\n");
+                if (prop.PropertyType.IsGenericType &&
+                    prop.PropertyType.GetGenericTypeDefinition() == typeof(LuaFunctionRef<>))
+                {
+                    GenerateFunctionAnnotations(sb, prop, fieldAttr, prop.Name, ctx);
+                }
+                else
+                {
+                    var luaType = InferLuaType(prop, ctx);
+                    if (fieldAttr.Description is { } desc)
+                        sb.Append($"---{desc}\n");
+                    sb.Append($"---@type {luaType}\n");
+                    sb.Append($"{prop.Name} = {fieldAttr.DefaultValue}\n\n");
+                }
             }
         }
 

--- a/LuaRenamer/LuaContext.cs
+++ b/LuaRenamer/LuaContext.cs
@@ -131,7 +131,7 @@ public class LuaContext : Lua
           end
           """;
 
-    private string EpNums(int pad) => string.Join(' ', _args.Episodes.Select(se => se.AnidbEpisode)
+    private string EpNums(long pad) => string.Join(' ', _args.Episodes.Select(se => se.AnidbEpisode)
         .Where(e => e.SeriesID == _primarySeries.AnidbAnimeID)
         .OrderBy(e => e.Type).ThenBy(e => e.EpisodeNumber)
         .Select((e, i) => (e.Type, RangeId: e.EpisodeNumber - i, Num: e.EpisodeNumber)) // RangeId effectively groups sequences of numbers
@@ -197,11 +197,11 @@ public class LuaContext : Lua
 
         _ = new EnvTable(env)
         {
-            episode_numbers = EpNums,
-            logdebug = LogDebug,
-            log = Log,
-            logwarn = LogWarn,
-            logerror = LogError,
+            episode_numbers = (Func<long, string>)EpNums,
+            logdebug = (Action<string>)LogDebug,
+            log = (Action<string>)Log,
+            logwarn = (Action<string>)LogWarn,
+            logerror = (Action<string>)LogError,
             replace_illegal_chars = _args.Configuration.ReplaceIllegalCharacters,
             remove_illegal_chars = _args.Configuration.RemoveIllegalCharacters,
             use_existing_anime_location = _args.Configuration.UseExistingAnimeLocation,
@@ -259,8 +259,9 @@ public class LuaContext : Lua
         return Cached<IAnidbAnime, AnimeTable>(anime.ID, tbl =>
         {
             var series = anime.ShokoSeries.FirstOrDefault();
-            return new AnimeTable(tbl, getname: _getName)
+            return new AnimeTable(tbl)
             {
+                getname = _getName,
                 airdate = DateTimeToTable(anime.AirDate?.ToDateTime()),
                 enddate = DateTimeToTable(anime.EndDate?.ToDateTime()),
                 rating = anime.Rating,
@@ -330,8 +331,9 @@ public class LuaContext : Lua
     }
 
     private LuaRef<EpisodeTable> EpisodeToTable(IAnidbEpisode episode) =>
-        Cached<IAnidbEpisode, EpisodeTable>(episode.ID, tbl => new EpisodeTable(tbl, getname: _getName)
+        Cached<IAnidbEpisode, EpisodeTable>(episode.ID, tbl => new EpisodeTable(tbl)
         {
+            getname = _getName,
             duration = (long)episode.Runtime.TotalSeconds,
             number = episode.EpisodeNumber,
             type = episode.Type,
@@ -446,8 +448,9 @@ public class LuaContext : Lua
         };
 
     private LuaRef<TmdbMovieTable> TmdbMovieToTable(ITmdbMovie movie) =>
-        new TmdbMovieTable(GetNewTable(), getname: _getName)
+        new TmdbMovieTable(GetNewTable())
         {
+            getname = _getName,
             id = movie.ID,
             titles = ArrayOf(movie.Titles.Select(TitleToTable)),
             defaultname = string.IsNullOrWhiteSpace(movie.DefaultTitle?.Value) ? null : movie.DefaultTitle?.Value,
@@ -459,8 +462,9 @@ public class LuaContext : Lua
         };
 
     private LuaRef<TmdbShowTable> TmdbShowToTable(ITmdbShow show) =>
-        new TmdbShowTable(GetNewTable(), getname: _getName)
+        new TmdbShowTable(GetNewTable())
         {
+            getname = _getName,
             id = show.ID,
             titles = ArrayOf(show.Titles.Select(TitleToTable)),
             defaultname = string.IsNullOrWhiteSpace(show.DefaultTitle?.Value) ? null : show.DefaultTitle?.Value,
@@ -475,8 +479,9 @@ public class LuaContext : Lua
         };
 
     private LuaRef<TmdbEpisodeTable> TmdbEpisodeToTable(ITmdbEpisode episode) =>
-        new TmdbEpisodeTable(GetNewTable(), getname: _getName)
+        new TmdbEpisodeTable(GetNewTable())
         {
+            getname = _getName,
             showid = episode.SeriesID,
             id = episode.ID,
             titles = ArrayOf(episode.Titles.Select(TitleToTable)),

--- a/LuaRenamer/LuaEnv/AnimeTable.cs
+++ b/LuaRenamer/LuaEnv/AnimeTable.cs
@@ -1,5 +1,6 @@
 // ReSharper disable InconsistentNaming
 
+using System;
 using LuaRenamer.LuaEnv.Attributes;
 using LuaRenamer.LuaEnv.BaseTypes;
 using NLua;
@@ -10,8 +11,10 @@ namespace LuaRenamer.LuaEnv;
 [LuaType(LuaTypeNames.Anime)]
 public partial class AnimeTable : LuaTableWriter
 {
-    internal AnimeTable(LuaTable t, LuaFunction getname) : base(t, _classidVal)
-        => _t["getname"] = getname;
+    internal AnimeTable(LuaTable t) : base(t, _classidVal) { }
+
+    [LuaField("Get the anime title in the specified language")]
+    public required LuaFunctionRef<Func<TitleLanguage, bool?, string?>> getname { init => Set(value.Value); }
 
     [LuaField("First air date of the anime")]
     public required LuaRef<DateTimeTable>? airdate { init => Set(value?.Table); }
@@ -39,12 +42,6 @@ public partial class AnimeTable : LuaTableWriter
 
     [LuaField("All available titles for the anime")]
     public required LuaArray<LuaRef<TitleTable>> titles { init => Set(value.Table); }
-
-    [LuaType(LuaTypeNames.function, "Get the anime title in the specified language")]
-    [LuaParameter(nameof(lang), nameof(EnumsTable.Language), "The language to get the title in")]
-    [LuaParameter(nameof(include_unofficial), $"{LuaTypeNames.boolean}|{LuaTypeNames.nil}", "Whether to include unofficial titles")]
-    [LuaReturnType($"{LuaTypeNames.@string}|{LuaTypeNames.nil}")]
-    public string getname(string lang, string? include_unofficial = null) => GetFunc([lang, include_unofficial], ':');
 
     [LuaField("Count of episodes by type")]
     public required LuaMap<EpisodeType, long> episodecounts { init => Set(value.Table); }

--- a/LuaRenamer/LuaEnv/BaseTypes/LuaFunctionRef.cs
+++ b/LuaRenamer/LuaEnv/BaseTypes/LuaFunctionRef.cs
@@ -1,0 +1,20 @@
+using System;
+using NLua;
+
+namespace LuaRenamer.LuaEnv.BaseTypes;
+
+/// <summary>
+/// A unified wrapper for a Lua function binding. Carries the delegate signature in its generic
+/// parameter <typeparamref name="TDelegate"/> so the source/definition generators can derive the
+/// Lua parameter and return types without dedicated function attributes. Accepts either a CLR
+/// delegate (bound by LuaContext) or an existing <see cref="LuaFunction"/> handle.
+/// </summary>
+public readonly struct LuaFunctionRef<TDelegate> where TDelegate : Delegate
+{
+    // object because NLua accepts both delegates and LuaFunction as boxed objects for _t[key] = value.
+    public object Value { get; }
+    public LuaFunctionRef(TDelegate callable) => Value = callable;
+    public LuaFunctionRef(LuaFunction luaFunction) => Value = luaFunction;
+    public static implicit operator LuaFunctionRef<TDelegate>(TDelegate callable) => new(callable);
+    public static implicit operator LuaFunctionRef<TDelegate>(LuaFunction luaFunction) => new(luaFunction);
+}

--- a/LuaRenamer/LuaEnv/EnumsTable.cs
+++ b/LuaRenamer/LuaEnv/EnumsTable.cs
@@ -1,3 +1,4 @@
+using LuaRenamer.LuaEnv.Attributes;
 using LuaRenamer.LuaEnv.BaseTypes;
 using NLua;
 using Shoko.Abstractions.Metadata.Enums;
@@ -9,12 +10,19 @@ public class EnumsTable : LuaRootTableWriter
 {
     internal EnumsTable(LuaTable t) : base(t) { }
 
+    [LuaField]
     public required LuaEnumRef<DropFolderType> importFolderType { init => Set(value.Table, nameof(ImportFolderType)); }
+    [LuaField]
     public required LuaEnumRef<AnimeType> animeType { init => Set(value.Table, nameof(AnimeType)); }
+    [LuaField]
     public required LuaEnumRef<EpisodeType> episodeType { init => Set(value.Table, nameof(EpisodeType)); }
+    [LuaField]
     public required LuaEnumRef<TitleType> titleType { init => Set(value.Table, nameof(TitleType)); }
+    [LuaField]
     public required LuaEnumRef<TitleLanguage> language { init => Set(value.Table, nameof(Language)); }
+    [LuaField]
     public required LuaEnumRef<RelationType> relationType { init => Set(value.Table, nameof(RelationType)); }
+    [LuaField]
     public required LuaEnumRef<YearlySeason> seasonName { init => Set(value.Table, nameof(SeasonName)); }
 
     public static EnumTable<DropFolderType> ImportFolderType => new() { Fn = Get() };

--- a/LuaRenamer/LuaEnv/EnvTable.cs
+++ b/LuaRenamer/LuaEnv/EnvTable.cs
@@ -11,30 +11,20 @@ public partial class EnvTable : LuaRootTableWriter
 {
     internal EnvTable(LuaTable t) : base(t) { }
 
-    [LuaType(LuaTypeNames.function, "Returns formatted episode numbers with padding")]
-    [LuaParameter("pad", LuaTypeNames.integer, "The amount of padding to use")]
-    [LuaReturnType(LuaTypeNames.@string)]
-    public required Func<int, string> episode_numbers { init => Set(value); }
+    [LuaField("Returns formatted episode numbers with padding")]
+    public required LuaFunctionRef<Func<long, string>> episode_numbers { init => Set(value.Value); }
 
-    [LuaType(LuaTypeNames.function, "Log with Debug log level")]
-    [LuaParameter("message", LuaTypeNames.@string, "The message to log")]
-    [LuaReturnType(LuaTypeNames.nil)]
-    public required Action<string> logdebug { init => Set(value); }
+    [LuaField("Log with Debug log level")]
+    public required LuaFunctionRef<Action<string>> logdebug { init => Set(value.Value); }
 
-    [LuaType(LuaTypeNames.function, "Log with Information log level")]
-    [LuaParameter("message", LuaTypeNames.@string, "The message to log")]
-    [LuaReturnType(LuaTypeNames.nil)]
-    public required Action<string> log { init => Set(value); }
+    [LuaField("Log with Information log level")]
+    public required LuaFunctionRef<Action<string>> log { init => Set(value.Value); }
 
-    [LuaType(LuaTypeNames.function, "Log with Warning log level")]
-    [LuaParameter("message", LuaTypeNames.@string, "The message to log")]
-    [LuaReturnType(LuaTypeNames.nil)]
-    public required Action<string> logwarn { init => Set(value); }
+    [LuaField("Log with Warning log level")]
+    public required LuaFunctionRef<Action<string>> logwarn { init => Set(value.Value); }
 
-    [LuaType(LuaTypeNames.function, "Log with Error log level")]
-    [LuaParameter("message", LuaTypeNames.@string, "The message to log")]
-    [LuaReturnType(LuaTypeNames.nil)]
-    public required Action<string> logerror { init => Set(value); }
+    [LuaField("Log with Error log level")]
+    public required LuaFunctionRef<Action<string>> logerror { init => Set(value.Value); }
 
     [LuaField("The current file being processed")]
     public required LuaRef<FileTable> file { init => Set(value.Table); }

--- a/LuaRenamer/LuaEnv/EpisodeTable.cs
+++ b/LuaRenamer/LuaEnv/EpisodeTable.cs
@@ -1,5 +1,6 @@
 // ReSharper disable InconsistentNaming
 
+using System;
 using LuaRenamer.LuaEnv.Attributes;
 using LuaRenamer.LuaEnv.BaseTypes;
 using NLua;
@@ -10,8 +11,10 @@ namespace LuaRenamer.LuaEnv;
 [LuaType(LuaTypeNames.Episode)]
 public partial class EpisodeTable : LuaTableWriter
 {
-    internal EpisodeTable(LuaTable t, LuaFunction getname) : base(t, _classidVal)
-        => _t["getname"] = getname;
+    internal EpisodeTable(LuaTable t) : base(t, _classidVal) { }
+
+    [LuaField("Get the title in the specified language")]
+    public required LuaFunctionRef<Func<TitleLanguage, string?>> getname { init => Set(value.Value); }
 
     [LuaField("Duration of the episode in seconds")]
     public required long duration { init => Set(value); }
@@ -33,11 +36,6 @@ public partial class EpisodeTable : LuaTableWriter
 
     [LuaField("All available titles for the episode")]
     public required LuaArray<LuaRef<TitleTable>> titles { init => Set(value.Table); }
-
-    [LuaType(LuaTypeNames.function, "Get the episode title in the specified language")]
-    [LuaParameter(nameof(lang), nameof(EnumsTable.Language), "The language to get the title in")]
-    [LuaReturnType($"{LuaTypeNames.@string}|{LuaTypeNames.nil}")]
-    public string getname(string lang) => GetFunc([lang], ':');
 
     [LuaField("Episode number type prefix (e.g., '', 'C', 'S', 'T', 'P', 'O')")]
     public required string prefix { init => Set(value); }

--- a/LuaRenamer/LuaEnv/TmdbEpisodeTable.cs
+++ b/LuaRenamer/LuaEnv/TmdbEpisodeTable.cs
@@ -1,5 +1,6 @@
 // ReSharper disable InconsistentNaming
 
+using System;
 using LuaRenamer.LuaEnv.Attributes;
 using LuaRenamer.LuaEnv.BaseTypes;
 using NLua;
@@ -10,8 +11,10 @@ namespace LuaRenamer.LuaEnv;
 [LuaType(LuaTypeNames.TmdbEpisode)]
 public partial class TmdbEpisodeTable : LuaTableWriter
 {
-    internal TmdbEpisodeTable(LuaTable t, LuaFunction getname) : base(t)
-        => _t["getname"] = getname;
+    internal TmdbEpisodeTable(LuaTable t) : base(t) { }
+
+    [LuaField("Get the title in the specified language")]
+    public required LuaFunctionRef<Func<TitleLanguage, string?>> getname { init => Set(value.Value); }
 
     [LuaField("TMDB episode ID")]
     public required long id { init => Set(value); }
@@ -39,11 +42,6 @@ public partial class TmdbEpisodeTable : LuaTableWriter
 
     [LuaField("Air date of the episode")]
     public required LuaRef<DateTimeTable>? airdate { init => Set(value?.Table); }
-
-    [LuaType(LuaTypeNames.function, "Get the episode title in the specified language")]
-    [LuaParameter(nameof(lang), nameof(EnumsTable.Language), "The language to get the title in")]
-    [LuaReturnType($"{LuaTypeNames.@string}|{LuaTypeNames.nil}")]
-    public string getname(string lang) => GetFunc([lang], ':');
 
     public static implicit operator LuaRef<TmdbEpisodeTable>(TmdbEpisodeTable t) => new(t._t);
 }

--- a/LuaRenamer/LuaEnv/TmdbMovieTable.cs
+++ b/LuaRenamer/LuaEnv/TmdbMovieTable.cs
@@ -1,16 +1,20 @@
 // ReSharper disable InconsistentNaming
 
+using System;
 using LuaRenamer.LuaEnv.Attributes;
 using LuaRenamer.LuaEnv.BaseTypes;
 using NLua;
+using Shoko.Abstractions.Metadata.Enums;
 
 namespace LuaRenamer.LuaEnv;
 
 [LuaType(LuaTypeNames.TmdbMovie)]
 public partial class TmdbMovieTable : LuaTableWriter
 {
-    internal TmdbMovieTable(LuaTable t, LuaFunction getname) : base(t)
-        => _t["getname"] = getname;
+    internal TmdbMovieTable(LuaTable t) : base(t) { }
+
+    [LuaField("Get the title in the specified language")]
+    public required LuaFunctionRef<Func<TitleLanguage, string?>> getname { init => Set(value.Value); }
 
     [LuaField("TMDB movie ID")]
     public required long id { init => Set(value); }
@@ -35,11 +39,6 @@ public partial class TmdbMovieTable : LuaTableWriter
 
     [LuaField("Air date of the movie")]
     public required LuaRef<DateTimeTable>? airdate { init => Set(value?.Table); }
-
-    [LuaType(LuaTypeNames.function, "Get the movie title in the specified language")]
-    [LuaParameter(nameof(lang), nameof(EnumsTable.Language), "The language to get the title in")]
-    [LuaReturnType($"{LuaTypeNames.@string}|{LuaTypeNames.nil}")]
-    public string getname(string lang) => GetFunc([lang], ':');
 
     public static implicit operator LuaRef<TmdbMovieTable>(TmdbMovieTable t) => new(t._t);
 }

--- a/LuaRenamer/LuaEnv/TmdbShowTable.cs
+++ b/LuaRenamer/LuaEnv/TmdbShowTable.cs
@@ -1,16 +1,20 @@
 // ReSharper disable InconsistentNaming
 
+using System;
 using LuaRenamer.LuaEnv.Attributes;
 using LuaRenamer.LuaEnv.BaseTypes;
 using NLua;
+using Shoko.Abstractions.Metadata.Enums;
 
 namespace LuaRenamer.LuaEnv;
 
 [LuaType(LuaTypeNames.TmdbShow)]
 public partial class TmdbShowTable : LuaTableWriter
 {
-    internal TmdbShowTable(LuaTable t, LuaFunction getname) : base(t)
-        => _t["getname"] = getname;
+    internal TmdbShowTable(LuaTable t) : base(t) { }
+
+    [LuaField("Get the title in the specified language")]
+    public required LuaFunctionRef<Func<TitleLanguage, string?>> getname { init => Set(value.Value); }
 
     [LuaField("TMDB show ID")]
     public required long id { init => Set(value); }
@@ -41,11 +45,6 @@ public partial class TmdbShowTable : LuaTableWriter
 
     [LuaField("End date of the show")]
     public required LuaRef<DateTimeTable>? enddate { init => Set(value?.Table); }
-
-    [LuaType(LuaTypeNames.function, "Get the show title in the specified language")]
-    [LuaParameter(nameof(lang), nameof(EnumsTable.Language), "The language to get the title in")]
-    [LuaReturnType($"{LuaTypeNames.@string}|{LuaTypeNames.nil}")]
-    public string getname(string lang) => GetFunc([lang], ':');
 
     [LuaField("List of seasons show aired during")]
     public required LuaArray<LuaRef<SeasonTable>> seasons { init => Set(value.Table); }

--- a/LuaRenamer/lua/defs.lua
+++ b/LuaRenamer/lua/defs.lua
@@ -35,10 +35,10 @@ local AniDbMedia = {}
 local Anime = {}
 
 ---Get the anime title in the specified language
----@param lang Language The language to get the title in
----@param include_unofficial boolean|nil Whether to include unofficial titles
+---@param p0 Language
+---@param p1 boolean|nil
 ---@return string|nil
-function Anime:getname(lang, include_unofficial) end
+function Anime:getname(p0, p1) end
 
 ---@class (exact) Audio
 ---@field compressionmode string # Audio compression mode
@@ -72,10 +72,10 @@ local DateTime = {}
 ---@field prefix string # Episode number type prefix (e.g., '', 'C', 'S', 'T', 'P', 'O')
 local Episode = {}
 
----Get the episode title in the specified language
----@param lang Language The language to get the title in
+---Get the title in the specified language
+---@param p0 Language
 ---@return string|nil
-function Episode:getname(lang) end
+function Episode:getname(p0) end
 
 ---@class (exact) File
 ---@field name string # The name of the file without extension
@@ -158,10 +158,10 @@ local Tmdb = {}
 ---@field airdate DateTime|nil # Air date of the episode
 local TmdbEpisode = {}
 
----Get the episode title in the specified language
----@param lang Language The language to get the title in
+---Get the title in the specified language
+---@param p0 Language
 ---@return string|nil
-function TmdbEpisode:getname(lang) end
+function TmdbEpisode:getname(p0) end
 
 ---@class (exact) TmdbMovie
 ---@field id integer # TMDB movie ID
@@ -174,10 +174,10 @@ function TmdbEpisode:getname(lang) end
 ---@field airdate DateTime|nil # Air date of the movie
 local TmdbMovie = {}
 
----Get the movie title in the specified language
----@param lang Language The language to get the title in
+---Get the title in the specified language
+---@param p0 Language
 ---@return string|nil
-function TmdbMovie:getname(lang) end
+function TmdbMovie:getname(p0) end
 
 ---@class (exact) TmdbShow
 ---@field id integer # TMDB show ID
@@ -193,10 +193,10 @@ function TmdbMovie:getname(lang) end
 ---@field seasons Season[] # List of seasons show aired during
 local TmdbShow = {}
 
----Get the show title in the specified language
----@param lang Language The language to get the title in
+---Get the title in the specified language
+---@param p0 Language
 ---@return string|nil
-function TmdbShow:getname(lang) end
+function TmdbShow:getname(p0) end
 
 ---@class (exact) Video
 ---@field height integer # Video height in pixels

--- a/LuaRenamer/lua/env.lua
+++ b/LuaRenamer/lua/env.lua
@@ -1,29 +1,29 @@
 ---@meta
 
 ---Returns formatted episode numbers with padding
----@param pad integer The amount of padding to use
+---@param p0 integer
 ---@return string
-function episode_numbers(pad) end
+function episode_numbers(p0) end
 
 ---Log with Debug log level
----@param message string The message to log
+---@param p0 string
 ---@return nil
-function logdebug(message) end
+function logdebug(p0) end
 
 ---Log with Information log level
----@param message string The message to log
+---@param p0 string
 ---@return nil
-function log(message) end
+function log(p0) end
 
 ---Log with Warning log level
----@param message string The message to log
+---@param p0 string
 ---@return nil
-function logwarn(message) end
+function logwarn(p0) end
 
 ---Log with Error log level
----@param message string The message to log
+---@param p0 string
 ---@return nil
-function logerror(message) end
+function logerror(p0) end
 
 ---The current file being processed
 ---@type File


### PR DESCRIPTION
## Summary

Unit 1 of 2: core runtime + generator changes introducing `LuaFunctionRef<TDelegate>`, a single wrapper for all Lua function bindings. It carries the delegate signature in its generic parameter so the generators derive Lua parameter/return types without the `[LuaType(function)]` / `[LuaParameter]` / `[LuaReturnType]` attributes or `LuaFunction` constructor parameters.

## Changes

- **New** `LuaFunctionRef<TDelegate>` struct with implicit conversions from a CLR delegate and from an NLua `LuaFunction`.
- **EnvTable**: the 5 function bindings (`episode_numbers`, `log`/`logdebug`/`logwarn`/`logerror`) become `LuaFunctionRef` `[LuaField]` init properties. `episode_numbers` pad arg is now `long` (so `InferLuaTypeForInner` maps it to `integer`).
- **AnimeTable / EpisodeTable / TmdbMovieTable / TmdbShowTable / TmdbEpisodeTable**: `getname` moves from a `LuaFunction` constructor argument + attributed method to a `LuaFunctionRef` `required init` property; constructors drop the `getname` parameter.
- **EnumsTable**: `[LuaField]` added to the instance `LuaEnumRef<T>` props so the NamesGenerator emits an `EnumsNames` class.
- **LuaContext**: `EpNums(long)`; `getname` / log methods / `episode_numbers` moved into object initializers (with explicit `Func`/`Action` casts on the method groups).
- **NamesGenerator**: emits nav methods from `LuaFunctionRef` props and `EnumTable<T>` nav props from `LuaEnumRef` props; the two `[LuaType(function)]` cases are removed.
- **LuaDefsGenerator**: function annotations and the enum map are derived from `LuaFunctionRef` / `LuaEnumRef` reflection (`InferLuaTypeForArg` helper added).
- Regenerated `lua/defs.lua` and `lua/env.lua`.

## Verification

- `dotnet build LuaRenamer.slnx`: 0 errors, 0 warnings.
- `dotnet test LuaRenamer.slnx`: 60/60 pass (incl. `TestEnumDefs`, `TestGetName`, `TestLuaDocsGenerator`).
- Generated `LuaNames.g.cs` verified: `AnimeNames.getname(string p0, string? p1 = null)`, `EpisodeNames.getname(string p0)`, `EnvNames.episode_numbers(string p0)`, and `EnumsNames` with 7 PascalCase `EnumTable<T>` static props.

## Deviations from the spec (intentional)

- **Step 4b deferred**: the static `EnumTable<T>` nav props on `EnumsTable` are retained, not removed. Their only consumers are in `LuaTests.cs` (e.g. `EnumsTable.Language[...]` used by `TestGetName`/`TestAnime`), which Unit 2 migrates to `EnumsNames`. Removing them now would break those tests, which are out of this unit's scope.
- **Function param docs degrade to positional `p0`/`p1`** in `defs.lua` / `env.lua`, and per-parameter descriptions are dropped. This is inherent to dropping `[LuaParameter]` — a delegate type carries no parameter names at runtime. Function names, types, and nullability are preserved.

## Base branch note

This PR targets `class-basedv2`, the prerequisite baseline (commits "Initial" + "2" on top of `class-based`'s `refactor luacontext`). That baseline existed only locally; I pushed it to origin so this PR shows the Unit 1 diff in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)