### PR TITLE
Expose per-episode TMDB movie links in tmdb.movies table

### DIFF
--- a/LuaRenamer/LuaContext.cs
+++ b/LuaRenamer/LuaContext.cs
@@ -457,6 +457,7 @@ public class LuaContext : Lua
                 .SelectMany(e => e.TmdbEpisodes.Select(e2 => new TmdbEpisodeTableBuilder(GetNewTable())
                     .showid(e2.SeriesID)
                     .id(e2.ID)
+                    .anidbepisodeid(e.AnidbEpisodeID)
                     .titles(ArrayOf(e2.Titles.Select(TitleToTable)))
                     .defaultname(string.IsNullOrWhiteSpace(e2.DefaultTitle?.Value) ? null : e2.DefaultTitle?.Value)
                     .preferredname(string.IsNullOrWhiteSpace(e2.PreferredTitle?.Value) ? null : e2.PreferredTitle?.Value)

--- a/LuaRenamer/LuaContext.cs
+++ b/LuaRenamer/LuaContext.cs
@@ -421,17 +421,24 @@ public class LuaContext : Lua
 
     private LuaRef<TmdbTable> TmdbToTable(LuaFunction getName) =>
         new TmdbTableBuilder(GetNewTable())
-            .movies(ArrayOf(_args.Series[0].TmdbMovies.Select(m => new TmdbMovieTableBuilder(GetNewTable())
-                .id(m.ID)
-                .titles(ArrayOf(m.Titles.Select(TitleToTable)))
-                .defaultname(string.IsNullOrWhiteSpace(m.DefaultTitle?.Value) ? null : m.DefaultTitle?.Value)
-                .preferredname(string.IsNullOrWhiteSpace(m.PreferredTitle?.Value) ? null : m.PreferredTitle?.Value)
-                .rating(m.Rating)
-                .restricted(m.Restricted)
-                .studios(ArrayOf(m.Studios.Select(s => s.Name)))
-                .airdate(DateTimeToTable(m.ReleaseDate))
-                .getname(getName)
-                .Build())))
+            .movies(ArrayOf(_args.Series[0].TmdbMovieCrossReferences
+                .Where(x => x.TmdbMovie is not null)
+                .Select(x =>
+                {
+                    var m = x.TmdbMovie!;
+                    return new TmdbMovieTableBuilder(GetNewTable())
+                        .id(m.ID)
+                        .titles(ArrayOf(m.Titles.Select(TitleToTable)))
+                        .defaultname(string.IsNullOrWhiteSpace(m.DefaultTitle?.Value) ? null : m.DefaultTitle?.Value)
+                        .preferredname(string.IsNullOrWhiteSpace(m.PreferredTitle?.Value) ? null : m.PreferredTitle?.Value)
+                        .rating(m.Rating)
+                        .restricted(m.Restricted)
+                        .studios(ArrayOf(m.Studios.Select(s => s.Name)))
+                        .airdate(DateTimeToTable(m.ReleaseDate))
+                        .anidbepisodeid(x.AnidbEpisodeID)
+                        .getname(getName)
+                        .Build();
+                })))
             .shows(ArrayOf(_args.Series[0].TmdbShows.Select(s => new TmdbShowTableBuilder(GetNewTable())
                 .id(s.ID)
                 .titles(ArrayOf(s.Titles.Select(TitleToTable)))

--- a/LuaRenamer/LuaEnv/TmdbEpisodeTable.cs
+++ b/LuaRenamer/LuaEnv/TmdbEpisodeTable.cs
@@ -14,6 +14,9 @@ public class TmdbEpisodeTable : Table
     [LuaType(LuaTypeNames.integer, "TMDB show ID")]
     public string showid => Get();
 
+    [LuaType(LuaTypeNames.integer, "AniDB episode ID this TMDB episode is linked to; 0 when linked to the whole anime")]
+    public string anidbepisodeid => Get();
+
     [LuaType($"{LuaTypeNames.Title}[]", "All available titles for the episode")]
     public ArrayTable<TitleTable> titles => new() { Fn = Get() };
 

--- a/LuaRenamer/LuaEnv/TmdbMovieTable.cs
+++ b/LuaRenamer/LuaEnv/TmdbMovieTable.cs
@@ -11,6 +11,9 @@ public class TmdbMovieTable : Table
     [LuaType(LuaTypeNames.integer, "TMDB movie ID")]
     public string id => Get();
 
+    [LuaType(LuaTypeNames.integer, "AniDB episode ID this movie is linked to; 0 when linked to the whole anime")]
+    public string anidbepisodeid => Get();
+
     [LuaType($"{LuaTypeNames.Title}[]", "All available titles for the movie")]
     public ArrayTable<TitleTable> titles => new() { Fn = Get() };
 

--- a/LuaRenamer/lua/defs.lua
+++ b/LuaRenamer/lua/defs.lua
@@ -149,6 +149,7 @@ local Tmdb = {}
 ---@class (exact) TmdbEpisode
 ---@field id integer # TMDB episode ID
 ---@field showid integer # TMDB show ID
+---@field anidbepisodeid integer # AniDB episode ID this TMDB episode is linked to; 0 when linked to the whole anime
 ---@field titles Title[] # All available titles for the episode
 ---@field defaultname string|nil # Default episode title
 ---@field preferredname string|nil # Preferred episode title
@@ -165,6 +166,7 @@ function TmdbEpisode:getname(lang) end
 
 ---@class (exact) TmdbMovie
 ---@field id integer # TMDB movie ID
+---@field anidbepisodeid integer # AniDB episode ID this movie is linked to; 0 when linked to the whole anime
 ---@field titles Title[] # All available titles for the movie
 ---@field defaultname string|nil # Default movie title
 ---@field preferredname string|nil # Preferred movie title


### PR DESCRIPTION
## Why

AniDB movie-type entries often span multiple episodes where each episode maps to a **different** TMDB movie — e.g. *Mobile Suit Gundam: The Origin* (6 episodes → 6 movies), *Final Fantasy VII: Advent Children* (3 → 3), *Shadow Skill* (3 → 3). Shoko tracks these as episode→movie cross-references (`CrossRef_AniDB_TMDB_Movie`, which carries an `AnidbEpisodeID`).

The `tmdb.movies` table in the Lua environment was populated from `TmdbMovies` (movies linked at the **whole-series** level), so it carried no episode linkage. A renamer script had no way to tell which episode a given TMDB movie belonged to — every episode of a multi-movie anime resolved to an identical name, forcing either a shared folder or a collision at move time.

## What changed

- **`tmdb.movies` is now built from `TmdbMovieCrossReferences`** (Shoko episode → TMDB movie cross-refs) instead of `TmdbMovies`. Entries with a missing `TmdbMovie` are filtered out; each cross-ref yields one table entry.
- **New field `tmdb.movies[].anidbepisodeid`** (`integer`): the AniDB episode ID the movie is linked to. `0` when the movie is linked to the whole anime rather than a specific episode.
- **New field `tmdb.episodes[].anidbepisodeid`** (`integer`): the AniDB episode ID the TMDB episode is linked to, mirroring the movie change so scripts can attribute a TMDB episode to its AniDB episode directly (needed for show-typed cross-refs where AniDB episode type/number do not line up with TMDB's season/episode numbering).

## Impact

- **Multi-part movies become addressable per episode.** Scripts can match an episode to its movie via `anidbepisodeid` and sort each into its own TMDB movie folder, keeping part numbers only when several episodes share one movie.
- **Whole-anime movie links are still present** in the table, now identifiable by `anidbepisodeid == 0`.
- **Episode-level show linkage is now attributable.** `tmdb.episodes[].anidbepisodeid` lets a script decide per file whether it is a movie episode or a show episode, and pull the TMDB season/episode for the folder and marker.
- **Source of the table changed.** The enumerated set comes from cross-references rather than the direct whole-series link collection, so scripts should not assume membership ordering or a 1:1 series↔movie ratio. Existing consumers of `tmdb.movies[].id/titles/...` continue to work unchanged.
- No fields were removed or renamed; the change is additive for field access.

## Verification

- `dotnet build -c Release`: 0 warnings, 0 errors.
- Exercised by a renamer script in production planning that maps episodes to TMDB movie folders; `anidbepisodeid` is matched against the Shoko episode ID to select the correct movie folder per episode.