### PR TITLE
Relock all NuGet lock files on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: nuget
+    # "/" alone is enough: discovery expands LuaRenamer.slnx and reaches every project. Adding "/*"
+    # re-ran the identical analysis once per subdirectory and deduplicated the resulting PRs anyway.
     directories:
       - "/"
-      - "/*"
     schedule:
       interval: "weekly"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,15 +5,38 @@ on: pull_request
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      # Lets the lock file refresh below push back to a Dependabot branch. Fork PRs get a read-only
+      # token regardless of what is asked for here.
+      contents: write
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Dependabot PRs: check out the branch tip rather than the merge commit, so the refresh step
+        # below has somewhere to push. Every other PR keeps the default merge-commit checkout.
+        ref: ${{ github.actor == 'dependabot[bot]' && github.head_ref || '' }}
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
         cache: true
         cache-dependency-path: '**/packages.lock.json'
+    # Dependabot regenerates the lock file of only the first project that declares the bumped package
+    # (dependabot/dependabot-core#13950), but under central package management the bump lands in the
+    # shared Directory.Packages.props and invalidates every project's lock file. Relock them all here,
+    # in this job rather than a separate workflow: a GITHUB_TOKEN push does not retrigger workflows, so
+    # the locked restore below has to be the one that sees the fix.
+    - name: Refresh NuGet lock files
+      if: github.actor == 'dependabot[bot]'
+      run: |
+        dotnet restore --force-evaluate
+        if ! git diff --quiet -- '*packages.lock.json'; then
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m 'Regenerate NuGet lock files' -- '*packages.lock.json'
+          git push
+        fi
     - name: Restore
       run: dotnet restore --locked-mode
     - name: Build


### PR DESCRIPTION
## Problem

Dependabot PRs under central package management arrive with stale lock files and fail CI. #147 is the current example: it bumped `NLua` in `Directory.Packages.props` and regenerated `LuaEnv/packages.lock.json`, but left the other three at `1.7.8`, so the locked restore failed:

```
DefsGenerator.csproj : error NU1004: Mistmatch between the requestedVersion of a lock file
  dependency marked as CentralTransitive and the version specified in the central package
  management file. Lock file version [1.7.8, 2.0.0), central package management version [1.7.9, 2.0.0).
LuaRenamer.csproj / Tests.csproj : error NU1004: The package reference NLua version has changed...
```

The updater loops over the projects declaring a package and stops at the first one whose update actually modifies a file, re-restoring only that project. Grepping `Attempting to update` in the [job log](https://github.com/Mik1ll/LuaRenamer/actions/runs/31292019128/job/93190713669) shows it:

| Package | Projects attempted before it stopped |
|---|---|
| `NLua` | `/LuaEnv` — stopped immediately |
| `Microsoft.Extensions.Logging.Abstractions` | `/LuaEnv`, `/DefsGenerator`, `/LuaRenamer` |
| `MSTest` | `/LuaRenamer`, `/LuaEnv`, `/DefsGenerator`, `/Tests` |

Because the edit lands in the shared `Directory.Packages.props`, it invalidates all four lock files while only one gets re-restored. Known upstream bug: dependabot/dependabot-core#13950, dependabot/dependabot-core#10863.

Not the cause: `.slnx` parses fine (the root workspace expanded it), and `CentralTransitive` isn't special — the `Direct` entries in `LuaRenamer`/`Tests` went stale the same way.

## Changes

**`build-and-test.yml`** — a `Refresh NuGet lock files` step, gated on `github.actor == 'dependabot[bot]'`, runs `dotnet restore --force-evaluate` and pushes the regenerated lock files. It lives in the build job rather than a separate workflow because a `GITHUB_TOKEN` push does not retrigger workflows, so the existing `--locked-mode` restore has to be the one that sees the fix — the check then passes in the same run. Needs `contents: write` (workflows triggered by Dependabot [respect the `permissions:` key](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/), so no PAT); fork PRs get a read-only token regardless.

On Dependabot PRs this checks out the branch tip instead of the merge commit, which the push requires. Other PRs keep the default merge-commit checkout.

**`dependabot.yml`** — `directories` drops `"/*"`. The root `"/"` entry expands `LuaRenamer.slnx` and already reaches every project; `"/*"` re-ran the identical analysis once per subdirectory across the 7m35s job and deduplicated the resulting PRs anyway.

## Testing

Not exercised end to end — the relock path only fires on a Dependabot-authored PR, so the next weekly run is the real test. Verified locally that the `'*packages.lock.json'` pathspec matches the nested lock files.

#147 predates this and won't self-heal; rebase it once this lands, or fix it directly with `dotnet restore --force-evaluate` on its branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
