### PR TITLE
Stop patch-sourcelink from emitting a lock file

### DIFF
--- a/scripts/patch-sourcelink.cs
+++ b/scripts/patch-sourcelink.cs
@@ -3,6 +3,9 @@
 // The repo uses Central Package Management (Directory.Packages.props), which forbids a
 // Version on PackageReference; opt this standalone tool out so #:package can pin one.
 #:property ManagePackageVersionsCentrally=false
+// Directory.Packages.props also switches lock files on, which would leave a stray
+// scripts/packages.lock.json behind on every run of this tool.
+#:property RestorePackagesWithLockFile=false
 // Copy NuGet assemblies next to the built app. Without this the file-based app's
 // runtimeconfig omits additionalProbingPaths, so Mono.Cecil isn't found at runtime.
 #:property CopyLocalLockFileAssemblies=true


### PR DESCRIPTION
`Directory.Packages.props` sets `RestorePackagesWithLockFile` repo-wide. The script already opts out of central package management so `#:package` can pin a version, but not out of lock files — so every `dotnet run scripts/patch-sourcelink.cs` dropped an untracked `scripts/packages.lock.json` pinning the file-based app's own ILCompiler/ILLink deps.

Verified: re-ran the tool after the change, patched pair still written correctly (NLua 1.7.9.0 with SourceLink), no lock file produced.

Independent of the MSTest/Shoko bumps — fold it in or merge separately, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)