### PR TITLE
Temporarily downgrade Moq to 4.20.70

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
         <PackageVersion Include="KeraLua" Version="[1.4.9, 2.0.0)" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.0.10, 11.0.0)" />
         <PackageVersion Include="NLua" Version="[1.7.9, 2.0.0)" />
-        <PackageVersion Include="Moq" Version="[4.20.72, 5.0.0)" />
+        <PackageVersion Include="Moq" Version="[4.20.70, 5.0.0)" />
         <PackageVersion Include="MSTest" Version="[4.3.3, 5.0.0)" />
     </ItemGroup>
 </Project>

--- a/Tests/packages.lock.json
+++ b/Tests/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "Moq": {
         "type": "Direct",
-        "requested": "[4.20.72, 5.0.0)",
-        "resolved": "4.20.72",
-        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "requested": "[4.20.70, 5.0.0)",
+        "resolved": "4.20.70",
+        "contentHash": "4rNnAwdpXJBuxqrOCzCyICXHSImOTRktCgCWXWykuF1qwoIsVvEnR7PjbMk/eLOxWvhmj5Kwt+kDV3RGUYcNwg==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }


### PR DESCRIPTION
Bait, not a real change. Deliberately puts `Moq` one patch behind so Dependabot will open a genuine `dependabot[bot]` PR bumping it back to 4.20.72.

## What this tests

The only unverified link left in the Dependabot pipeline: whether a run whose actor is `dependabot[bot]` actually receives the `contents: write` elevation the workflow asks for. #152 proved the refresh regenerates and pushes lock files correctly, but it ran as a normal user. If the elevation does not hold, the Refresh step 403s on `git push` and Dependabot PRs go red again — in which case that step needs a PAT or app token.

Moq only reaches `Tests/packages.lock.json`, which is fine here: #152 already covered the multi-lock-file case. KeraLua would have exercised all four but 1.4.8 fails restore with 6 errors, since NLua 1.7.9 requires 1.4.9.

## After merging

1. Insights → Dependency graph → Dependabot → **Check for updates**
2. Watch the Refresh step on the resulting "Bump Moq from 4.20.70 to 4.20.72" PR
3. Merge it — that restores 4.20.72 and reverts this

Verified locally on the downgrade: clean build, 96/96 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)